### PR TITLE
update naming remove step4 prefix

### DIFF
--- a/skills/root-cause-analysis/README.md
+++ b/skills/root-cause-analysis/README.md
@@ -123,10 +123,10 @@ Required GitHub MCP tools:
 # Step 5: Claude analyzes the data and generates summary (automatic when skill is invoked)
 ```
 
-**Note**: The `cli.py analyze` command runs all steps (1-4) automatically. Step 4 can also be run separately if needed:
+**Note**: The `cli.py analyze` command runs all steps (1-4) automatically. The GitHub fetcher can also be run separately if needed:
 ```bash
-# Run step 4 separately (standalone execution)
-.venv/bin/python scripts/step4_fetch_github.py --job-id 1234567
+# Run GitHub fetcher separately (standalone execution)
+.venv/bin/python scripts/github_fetcher.py --job-id 1234567
 ```
 
 ### Analyze by Job ID
@@ -200,7 +200,7 @@ All steps are executed automatically by the `cli.py analyze` command:
 - Reports success/404 status for each file attempt
 - Output: `step4_github_fetch_history.json`
 
-**Post-Step4 GitHub MCP Verification**: If step4 output contains `"error": "all_paths_failed"` or any `"status": "404"` in `paths_tried` arrays, **MUST** verify 404 errors using MCP tools. See [post-step4-verification.md](post-step4-verification.md) for complete verification process.
+**GitHub MCP Verification**: If step4 output contains `"error": "all_paths_failed"` or any `"status": "404"` in `paths_tried` arrays, verify 404 errors using MCP tools. See [github_mcp_verification.md](github_mcp_verification.md) for complete verification process.
 
 ### Step 5: Analyze and Generate Summary (Claude)
 
@@ -288,8 +288,8 @@ The skill can read job logs in these formats:
 - **Note**: MCP tools are only used for 404 verification, not for fetching files
 
 ### Files Not Found (404 errors)
-- Step 4 script handles path variations automatically
-- If 404 errors occur, use GitHub MCP tools to verify (see Step 4 section above)
+- GitHub fetcher script handles path variations automatically
+- If 404 errors occur, use GitHub MCP tools to verify (see GitHub MCP Verification section above)
 - Check parent directories first before doing wild searches
 - Document findings to identify parser bugs vs truly missing files
 

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -67,7 +67,7 @@ python3 -m venv .venv
 
 ---
 
-**Post-Step4 GitHub MCP Verification**: If step4 output contains `"error": "all_paths_failed"` or any error status (e.g., `"status": "404"`, `"status": "timeout"`, `"status": "500"`) in `paths_tried` arrays, reasoning errors using MCP tools. See [post-step4-verification.md](post-step4-verification.md) for complete verification process.
+**GitHub MCP Verification**: If step4 output contains `"error": "all_paths_failed"` or any error status (e.g., `"status": "404"`, `"status": "timeout"`, `"status": "500"`) in `paths_tried` arrays, reasoning errors using MCP tools. See [github_mcp_verification.md](github_mcp_verification.md) for complete verification process.
 
 ---
 

--- a/skills/root-cause-analysis/github_mcp_verification.md
+++ b/skills/root-cause-analysis/github_mcp_verification.md
@@ -1,4 +1,4 @@
-# Post-Step4 GitHub MCP Verification for Errors
+# GitHub MCP Verification for Errors
 
 After step4 completes and outputs `step4_github_fetch_history.json`, Claude reasoning any errors (e.g., 404, timeout, HTTP errors) using MCP tools.
 

--- a/skills/root-cause-analysis/github_mcp_verification.md
+++ b/skills/root-cause-analysis/github_mcp_verification.md
@@ -1,6 +1,6 @@
 # GitHub MCP Verification for Errors
 
-After step4 completes and outputs `step4_github_fetch_history.json`, Claude reasoning any errors (e.g., 404, timeout, HTTP errors) using MCP tools.
+After GitHub fetch step completes and outputs `step4_github_fetch_history.json`, Claude reasoning any errors (e.g., 404, timeout, HTTP errors) using MCP tools.
 
 **Verification Process**:
 1. **Check parent directories** using `mcp__github__get_file_contents` to list actual folder/file names (reveals case sensitivity, hyphens vs underscores)

--- a/skills/root-cause-analysis/schemas/github_context.schema.json
+++ b/skills/root-cause-analysis/schemas/github_context.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "GitHub Context Fetch",
-  "description": "Step 4: Fetched GitHub configuration and code files with 404 error handling",
+  "description": "Fetched GitHub configuration and code files with 404 error handling",
   "type": "object",
   "required": ["job_id", "job_metadata", "github_fetches"],
   "properties": {

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -15,14 +15,14 @@ if __name__ == "__main__" and __package__ is None:
     from scripts.correlator import build_correlation_timeline, fetch_correlated_logs
     from scripts.job_parser import parse_job_log
     from scripts.log_fetcher import fetch_job_log
-    from scripts.step4_fetch_github import GitHubClient, Step4Analyzer
+    from scripts.github_fetcher import GitHubClient, GitHubAnalyzer
 else:
     # Running as module (-m scripts.cli)
     from .config import Config
     from .correlator import build_correlation_timeline, fetch_correlated_logs
     from .job_parser import parse_job_log
     from .log_fetcher import fetch_job_log
-    from .step4_fetch_github import GitHubClient, Step4Analyzer
+    from .github_fetcher import GitHubClient, GitHubAnalyzer
 
 
 def get_analysis_dir(config: Config, job_id: str) -> Path:
@@ -195,7 +195,7 @@ def cmd_analyze(args: argparse.Namespace, config: Config) -> int:
     else:
         try:
             github_client = GitHubClient(config.github_token)
-            analyzer = Step4Analyzer(job_id, analysis_dir, github_client)
+            analyzer = GitHubAnalyzer(job_id, analysis_dir, github_client)
             step4_result = analyzer.run()
             step4_path = save_step(analysis_dir, 4, step4_result)
             print(f"  GitHub fetches: {len(step4_result.get('github_fetches', []))}")

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -13,16 +13,16 @@ if __name__ == "__main__" and __package__ is None:
     sys.path.insert(0, str(Path(__file__).parent.parent))
     from scripts.config import Config
     from scripts.correlator import build_correlation_timeline, fetch_correlated_logs
+    from scripts.github_fetcher import GitHubAnalyzer, GitHubClient
     from scripts.job_parser import parse_job_log
     from scripts.log_fetcher import fetch_job_log
-    from scripts.github_fetcher import GitHubClient, GitHubAnalyzer
 else:
     # Running as module (-m scripts.cli)
     from .config import Config
     from .correlator import build_correlation_timeline, fetch_correlated_logs
+    from .github_fetcher import GitHubAnalyzer, GitHubClient
     from .job_parser import parse_job_log
     from .log_fetcher import fetch_job_log
-    from .github_fetcher import GitHubClient, GitHubAnalyzer
 
 
 def get_analysis_dir(config: Config, job_id: str) -> Path:

--- a/skills/root-cause-analysis/scripts/github_fetcher.py
+++ b/skills/root-cause-analysis/scripts/github_fetcher.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """
-Step 4: Fetch GitHub Data - Parse paths and fetch all relevant files
+Fetch GitHub Data - Parse paths and fetch all relevant files
 
 Fetches all relevant GitHub configuration and workload files.
 Real analysis happens in Step 5 when Claude reads and interprets the files.
 
 Usage:
-    python -m scripts.step4_fetch_github --job-id <JOB_ID>
+    python -m scripts.github_fetcher --job-id <JOB_ID>
 """
 
 import argparse
@@ -80,7 +80,7 @@ class GitHubClient:
             return None
 
 
-# Step 4a: Parse GitHub Paths Functions
+# Step a: Parse GitHub Paths Functions
 def parse_job_name(job_name: str, guid: str) -> dict[str, Any]:
     """Parse RHPDS job name using GUID as anchor."""
     warnings = []
@@ -179,8 +179,8 @@ def parse_task_path(task_path: str) -> dict[str, Any]:
     }
 
 
-class Step4Analyzer:
-    """Step 4: Parse paths, fetch files, analyze, generate root cause"""
+class GitHubAnalyzer:
+    """Parse paths, fetch files, analyze, generate root cause"""
 
     def __init__(self, job_id: str, analysis_dir: Path, github_client: GitHubClient):
         self.job_id = job_id
@@ -197,8 +197,8 @@ class Step4Analyzer:
             return json.load(f)
 
     def parse_failed_tasks(self, job_context: dict) -> dict:
-        """Step 4a: Parse failed tasks and extract file paths"""
-        print("[INFO] Step 4a: Parsing failed tasks...")
+        """Step a: Parse failed tasks and extract file paths"""
+        print("[INFO] Step a: Parsing failed tasks...")
 
         job_id = job_context.get("job_id", "")
         failed_tasks = job_context.get("failed_tasks", [])
@@ -244,8 +244,8 @@ class Step4Analyzer:
         }
 
     def fetch_configs(self, platform: str, catalog: str, env: str) -> dict:
-        """Step 4b: Fetch configs with backward discovery"""
-        print("[INFO] Step 4b: Fetching AgnosticV configurations...")
+        """Step b: Fetch configs with backward discovery"""
+        print("[INFO] Step b: Fetching AgnosticV configurations...")
 
         start_path = f"{platform}/{catalog}/{env}.yaml"
 
@@ -304,8 +304,8 @@ class Step4Analyzer:
         return fetched_configs
 
     def fetch_workload_code(self, investigation_targets: dict) -> dict:
-        """Step 4c: Fetch all AgnosticD workload code"""
-        print("[INFO] Step 4c: Fetching AgnosticD workload code...")
+        """Step c: Fetch all AgnosticD workload code"""
+        print("[INFO] Step c: Fetching AgnosticD workload code...")
 
         fetched_workload = {}
         workload_files = investigation_targets.get("workload_code", [])
@@ -347,8 +347,8 @@ class Step4Analyzer:
         return fetched_workload
 
     def run(self) -> dict:
-        """Execute full Step 4 - fetch all GitHub files"""
-        print(f"[INFO] Starting Step 4 analysis for job {self.job_id}...")
+        """Execute GitHub file fetching - fetch all GitHub files"""
+        print(f"[INFO] Starting GitHub file fetch for job {self.job_id}...")
 
         # Load Step 1 context
         job_context = self.load_step1()
@@ -359,10 +359,10 @@ class Step4Analyzer:
         metadata = parse_job_name(job_name, guid)
         warnings = metadata.get("warnings", [])
 
-        # Step 4a: Parse failed tasks (only parses task paths, not metadata)
+        # Step a: Parse failed tasks (only parses task paths, not metadata)
         github_paths = self.parse_failed_tasks(job_context)
 
-        # Step 4b: Fetch configs once. This ensures configs are fetched even if there are no failed tasks
+        # Step b: Fetch configs once. This ensures configs are fetched even if there are no failed tasks
         platform = metadata.get("platform", "")
         catalog = metadata.get("catalog_item", "")
         env = metadata.get("env", "")
@@ -373,7 +373,7 @@ class Step4Analyzer:
         else:
             print("[WARNING] Missing platform/catalog/env metadata - skipping config fetch")
 
-        # Step 4c: For each failed task, fetch workload code
+        # Step c: For each failed task, fetch workload code
         github_fetches = []
 
         for task in github_paths.get("failed_tasks", []):
@@ -410,7 +410,7 @@ class Step4Analyzer:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Step 4: Fetch all relevant GitHub configuration and workload files"
+        description="Fetch all relevant GitHub configuration and workload files"
     )
     parser.add_argument("--job-id", required=True, help="Job ID to analyze")
     args = parser.parse_args()
@@ -433,7 +433,7 @@ def main():
     github_client = GitHubClient(github_token)
 
     # Run analysis (using this skill's .analysis directory)
-    analyzer = Step4Analyzer(args.job_id, analysis_dir, github_client)
+    analyzer = GitHubAnalyzer(args.job_id, analysis_dir, github_client)
     result = analyzer.run()
 
     # Save output (for standalone usage)

--- a/skills/root-cause-analysis/scripts/github_fetcher.py
+++ b/skills/root-cause-analysis/scripts/github_fetcher.py
@@ -411,7 +411,7 @@ class GitHubAnalyzer:
         return result
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         description="Fetch all relevant GitHub configuration and workload files"
     )


### PR DESCRIPTION
- Removed "step4" prefix from all file names                                                                         
- Changed Step4Analyzer → GitHubAnalyzer                                                                             
- Updated step labels: "Step 4a/4b/4c" → "Step a/b/c"                                                                
- Updated all documentation links and references

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated and renamed the GitHub verification guidance for clearer, consistent instructions (now referencing the “GitHub fetcher”).
  * Updated headings, links, and guidance for post-fetch verification and handling missing files.

* **Chores**
  * Standardized naming and messaging for the GitHub data‑fetching component across docs and CLI output.
  * Removed “Step 4:” prefix from public descriptions for simpler wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->