### PR TITLE
Integrate known failure pattern classification into RCA skill

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "python-dotenv>=1.0.0",
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/skills/root-cause-analysis/README.md
+++ b/skills/root-cause-analysis/README.md
@@ -46,7 +46,8 @@ Add the following environment variables to your Claude Code settings file:
     "SPLUNK_INDEX": "your_splunk_index",
     "SPLUNK_OCP_APP_INDEX": "your_ocp_app_index",
     "SPLUNK_OCP_INFRA_INDEX": "your_ocp_infra_index",
-    "SPLUNK_VERIFY_SSL": "false"
+    "SPLUNK_VERIFY_SSL": "false",
+    "KNOWN_FAILED_YAML_URL": "https://api.github.com/repos/your-org/your-repo/contents/path/to/known_failed.yaml"
   }
 }
 ```
@@ -60,6 +61,7 @@ Update the values:
 - `SPLUNK_USERNAME` / `SPLUNK_PASSWORD` - Your Splunk credentials
 - `SPLUNK_INDEX` - Default index for AAP logs
 - `SPLUNK_OCP_APP_INDEX` / `SPLUNK_OCP_INFRA_INDEX` - OCP log indices
+- `KNOWN_FAILED_YAML_URL` - URL to `known_failed.yaml` for error classification (e.g., GitHub API content URL). Uses `GITHUB_TOKEN` for authentication if the URL points to `api.github.com`. The file is cached locally after first fetch. Alternatively, set `KNOWN_FAILED_YAML` to a local file path. Can also be passed via `--known-failures-url` or `--known-failures-file` CLI flags.
 
 ### 3. Configure SSH for auto-fetch (optional)
 
@@ -222,7 +224,7 @@ All steps are executed automatically by the `cli.py analyze` command:
 
 ### Step 5: Analyze and Generate Summary (Claude)
 
-**Input files**: Read outputs from steps 1-4 (`step1_job_context.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, and if needed, `step2_splunk_logs.json`).
+**Input files**: Read outputs from steps 1-4 (`step1_job_context.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, `classification.json`, and if needed, `step2_splunk_logs.json`).
 
 **Analysis Guidelines**:
 - **Configuration Analysis**: Variable precedence (role defaults → common.yaml → platform/account.yaml → platform/catalog/env.yaml), check for conflicts, missing variables, secrets references
@@ -259,6 +261,7 @@ Analysis results are saved to `.analysis/<job-id>/`:
 | `step2_splunk_logs.json` | Correlated Splunk pod logs | Python |
 | `step3_correlation.json` | Unified timeline with correlation proof | Python |
 | `step4_github_fetch_history.json` | GitHub fetch results (configs and workload code) | Python (Claude updates for MCP verification) |
+| `classification.json` | Known failure pattern matches | Python |
 | `step5_analysis_summary.json` | Root cause summary with recommendations | Claude |
 
 ## Correlation Methods

--- a/skills/root-cause-analysis/README.md
+++ b/skills/root-cause-analysis/README.md
@@ -46,7 +46,8 @@ Add the following environment variables to your Claude Code settings file:
     "SPLUNK_INDEX": "your_splunk_index",
     "SPLUNK_OCP_APP_INDEX": "your_ocp_app_index",
     "SPLUNK_OCP_INFRA_INDEX": "your_ocp_infra_index",
-    "SPLUNK_VERIFY_SSL": "false"
+    "SPLUNK_VERIFY_SSL": "false",
+    "KNOWN_FAILED_YAML_URL": "https://api.github.com/repos/your-org/your-repo/contents/path/to/known_failed.yaml"
   }
 }
 ```
@@ -60,6 +61,7 @@ Update the values:
 - `SPLUNK_USERNAME` / `SPLUNK_PASSWORD` - Your Splunk credentials
 - `SPLUNK_INDEX` - Default index for AAP logs
 - `SPLUNK_OCP_APP_INDEX` / `SPLUNK_OCP_INFRA_INDEX` - OCP log indices
+- `KNOWN_FAILED_YAML_URL` - URL to `known_failed.yaml` for error classification (e.g., GitHub API content URL). Uses `GITHUB_TOKEN` for authentication if the URL points to `api.github.com`. The file is cached locally after first fetch. Alternatively, set `KNOWN_FAILED_YAML` to a local file path. Can also be passed via `--known-failures-url` or `--known-failures-file` CLI flags.
 
 ### 3. Configure SSH for auto-fetch (optional)
 
@@ -204,7 +206,7 @@ All steps are executed automatically by the `cli.py analyze` command:
 
 ### Step 5: Analyze and Generate Summary (Claude)
 
-**Input files**: Read outputs from steps 1-4 (`step1_job_context.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, and if needed, `step2_splunk_logs.json`).
+**Input files**: Read outputs from steps 1-4 (`step1_job_context.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, `classification.json`, and if needed, `step2_splunk_logs.json`).
 
 **Analysis Guidelines**:
 - **Configuration Analysis**: Variable precedence (role defaults → common.yaml → platform/account.yaml → platform/catalog/env.yaml), check for conflicts, missing variables, secrets references
@@ -236,6 +238,7 @@ Analysis results are saved to `.analysis/<job-id>/`:
 | `step2_splunk_logs.json` | Correlated Splunk pod logs | Python |
 | `step3_correlation.json` | Unified timeline with correlation proof | Python |
 | `step4_github_fetch_history.json` | GitHub fetch results (configs and workload code) | Python (Claude updates for MCP verification) |
+| `classification.json` | Known failure pattern matches | Python |
 | `step5_analysis_summary.json` | Root cause summary with recommendations | Claude |
 
 ## Correlation Methods

--- a/skills/root-cause-analysis/README.md
+++ b/skills/root-cause-analysis/README.md
@@ -47,7 +47,7 @@ Add the following environment variables to your Claude Code settings file:
     "SPLUNK_OCP_APP_INDEX": "your_ocp_app_index",
     "SPLUNK_OCP_INFRA_INDEX": "your_ocp_infra_index",
     "SPLUNK_VERIFY_SSL": "false",
-    "KNOWN_FAILED_YAML_URL": "https://api.github.com/repos/your-org/your-repo/contents/path/to/known_failed.yaml"
+    "KNOWN_FAILED_YAML_URL": "https://raw.githubusercontent.com/<owner>/<repo>/<branch>/known_failed.yaml"
   }
 }
 ```
@@ -61,7 +61,12 @@ Update the values:
 - `SPLUNK_USERNAME` / `SPLUNK_PASSWORD` - Your Splunk credentials
 - `SPLUNK_INDEX` - Default index for AAP logs
 - `SPLUNK_OCP_APP_INDEX` / `SPLUNK_OCP_INFRA_INDEX` - OCP log indices
-- `KNOWN_FAILED_YAML_URL` - URL to `known_failed.yaml` for error classification (e.g., GitHub API content URL). Uses `GITHUB_TOKEN` for authentication if the URL points to `api.github.com`. The file is cached locally after first fetch. Alternatively, set `KNOWN_FAILED_YAML` to a local file path. Can also be passed via `--known-failures-url` or `--known-failures-file` CLI flags.
+- `KNOWN_FAILED_YAML_URL` / `KNOWN_FAILED_YAML` - **Optional** source of known failure patterns for error classification. The whole classification step is skipped gracefully if neither is set (the rest of the pipeline runs unchanged). You do **not** need a GitHub token — pick whichever source fits your access:
+  - **Local file** (no network): set `KNOWN_FAILED_YAML` to a path, or pass `--known-failures-file <path>`.
+  - **Plain raw URL over HTTP/curl** (no credentials): set `KNOWN_FAILED_YAML_URL` to a raw URL such as `https://raw.githubusercontent.com/<owner>/<repo>/<branch>/known_failed.yaml`, or pass `--known-failures-url <url>`. This is the recommended option for users who cannot use a GitHub token.
+  - **GitHub contents API** (`https://api.github.com/repos/<owner>/<repo>/contents/<path>/known_failed.yaml`): works with or without a token — the raw `Accept` header is always sent so unauthenticated requests still return file content. A `GITHUB_TOKEN`, if set, is used only to reach **private** repositories.
+
+  Fetched URLs are cached locally (keyed per URL) so a later fetch failure never falls back to patterns from a different source. CLI flags override the env vars. Do **not** commit real/private URLs — the examples above are placeholders.
 
 ### 3. Configure SSH for auto-fetch (optional)
 
@@ -158,6 +163,22 @@ Alternatively, specify the log file directly:
 ```bash
 .venv/bin/python scripts/cli.py analyze --job-log /path/to/job_1234567.json.gz
 ```
+
+### Classify Against Known Failure Patterns (optional)
+
+Provide a `known_failed.yaml` from a local file or a plain URL — no GitHub token required. If neither is supplied, classification is skipped and the rest of the pipeline runs normally.
+
+```bash
+# From a local file
+.venv/bin/python scripts/cli.py analyze --job-id 1234567 \
+  --known-failures-file /path/to/known_failed.yaml
+
+# From a raw URL over plain HTTP/curl (no credentials)
+.venv/bin/python scripts/cli.py analyze --job-id 1234567 \
+  --known-failures-url https://raw.githubusercontent.com/<owner>/<repo>/<branch>/known_failed.yaml
+```
+
+These flags override the `KNOWN_FAILED_YAML` / `KNOWN_FAILED_YAML_URL` env vars (see the configuration section above). The example URL is a placeholder — substitute your own repository.
 
 ### Other Commands
 

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -97,7 +97,7 @@ python3 -m venv .venv
 
 ### Summary Requirements
 
-1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|workload_bug|credential|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
+1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|application_bug|secrets|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
 2. **Evidence**: Supporting evidence from AAP logs, Splunk logs, and GitHub configs/code
    - **REQUIRED**: When `source` is `agnosticv_config` or `agnosticd_code`, **MUST** include `github_path` in format `owner/repo:path/to/file.yml:line`
    - Extract GitHub paths from step4:

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -44,7 +44,7 @@ The `cli.py analyze` command automatically runs all steps:
 - **Step 3**: Correlate → Merge AAP and Splunk events into unified timeline
 - **Step 4**: Fetch GitHub files → Parse job metadata, fetch AgnosticV configs and AgnosticD workload code (requires `GITHUB_TOKEN` to be configured)
 
-**Outputs**: `.analysis/<job-id>/step1_job_context.json`, `step2_splunk_logs.json`, `step3_correlation.json`, `step4_github_fetch_history.json`
+**Outputs**: `.analysis/<job-id>/step1_job_context.json`, `step2_splunk_logs.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, `classification.json`
 
 This skill automatically searches for job logs in the configured `JOB_LOGS_DIR`.
 
@@ -77,7 +77,8 @@ python3 -m venv .venv
 1. **REQUIRED**: `step1_job_context.json` - Job metadata and failed task details
 2. **REQUIRED**: `step3_correlation.json` - Correlated timeline with relevant pod logs (DO NOT read step2 unless needed)
 3. **REQUIRED**: `step4_github_fetch_history.json` - Configuration and code context
-4. **CONDITIONAL**: `step2_splunk_logs.json` - Only read if step3 indicates errors needing deeper investigation
+4. **REQUIRED**: `classification.json` - Known failure pattern matches (if present). Use these verified categories instead of guessing. If a match exists, use its `error_category` as the root cause category. If no matches, flag as novel/unclassified failure.
+5. **CONDITIONAL**: `step2_splunk_logs.json` - Only read if step3 indicates errors needing deeper investigation
 
 **Output**: `.analysis/<job-id>/step5_analysis_summary.json` 
 
@@ -96,7 +97,7 @@ python3 -m venv .venv
 
 ### Summary Requirements
 
-1. **Root Cause**: Category (`configuration|infrastructure|workload_bug|credential|resource|dependency`), summary, confidence
+1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|workload_bug|credential|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
 2. **Evidence**: Supporting evidence from AAP logs, Splunk logs, and GitHub configs/code
    - **REQUIRED**: When `source` is `agnosticv_config` or `agnosticd_code`, **MUST** include `github_path` in format `owner/repo:path/to/file.yml:line`
    - Extract GitHub paths from step4:
@@ -180,6 +181,7 @@ See `schemas/summary.schema.json` for complete structure. Example:
 | 2 | `step2_splunk_logs.json` | Python |
 | 3 | `step3_correlation.json` | Python |
 | 4 | `step4_github_fetch_history.json` | Python (Optional Claude updates for MCP verification) |
+| — | `classification.json` | Python (known failure pattern matching) |
 | 5 | `step5_analysis_summary.json` | Claude |
 
 All files in `.analysis/<job-id>/`

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -124,7 +124,7 @@ The `cli.py analyze` command automatically runs all steps:
 - **Step 3**: Correlate → Merge AAP and Splunk events into unified timeline
 - **Step 4**: Fetch GitHub files → Parse job metadata, fetch AgnosticV configs and AgnosticD workload code (requires `GITHUB_TOKEN` to be configured)
 
-**Outputs**: `.analysis/<job-id>/step1_job_context.json`, `step2_splunk_logs.json`, `step3_correlation.json`, `step4_github_fetch_history.json`
+**Outputs**: `.analysis/<job-id>/step1_job_context.json`, `step2_splunk_logs.json`, `step3_correlation.json`, `step4_github_fetch_history.json`, `classification.json`
 
 This skill automatically searches for job logs in the configured `JOB_LOGS_DIR`.
 
@@ -157,7 +157,8 @@ python3 -m venv .venv
 1. **REQUIRED**: `step1_job_context.json` - Job metadata and failed task details
 2. **REQUIRED**: `step3_correlation.json` - Correlated timeline with relevant pod logs (DO NOT read step2 unless needed)
 3. **REQUIRED**: `step4_github_fetch_history.json` - Configuration and code context
-4. **CONDITIONAL**: `step2_splunk_logs.json` - Only read if step3 indicates errors needing deeper investigation
+4. **REQUIRED**: `classification.json` - Known failure pattern matches (if present). Use these verified categories instead of guessing. If a match exists, use its `error_category` as the root cause category. If no matches, flag as novel/unclassified failure.
+5. **CONDITIONAL**: `step2_splunk_logs.json` - Only read if step3 indicates errors needing deeper investigation
 
 **Output**: `.analysis/<job-id>/step5_analysis_summary.json` 
 
@@ -181,7 +182,7 @@ python scripts/cli.py upload --job-id <job-id>
 
 ### Summary Requirements
 
-1. **Root Cause**: Category (`configuration|infrastructure|workload_bug|credential|resource|dependency`), summary, confidence
+1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|workload_bug|credential|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
 2. **Evidence**: Supporting evidence from AAP logs, Splunk logs, and GitHub configs/code
    - **REQUIRED**: When `source` is `agnosticv_config` or `agnosticd_code`, **MUST** include `github_path` in format `owner/repo:path/to/file.yml:line`
    - Extract GitHub paths from step4:
@@ -265,6 +266,7 @@ See `schemas/summary.schema.json` for complete structure. Example:
 | 2 | `step2_splunk_logs.json` | Python |
 | 3 | `step3_correlation.json` | Python |
 | 4 | `step4_github_fetch_history.json` | Python (Optional Claude updates for MCP verification) |
+| — | `classification.json` | Python (known failure pattern matching) |
 | 5 | `step5_analysis_summary.json` | Claude |
 
 All files in `.analysis/<job-id>/`

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -182,7 +182,7 @@ python scripts/cli.py upload --job-id <job-id>
 
 ### Summary Requirements
 
-1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|workload_bug|credential|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
+1. **Root Cause**: Category — prefer `classification.json` categories when matched (`platform_failure|connectivity_failure|authentication_failure|resource_failure|timeout_failure|automation_failure|infrastructure_failure`). Fall back to (`configuration|infrastructure|application_bug|secrets|resource|dependency`) only for novel/unclassified errors. Include summary and confidence.
 2. **Evidence**: Supporting evidence from AAP logs, Splunk logs, and GitHub configs/code
    - **REQUIRED**: When `source` is `agnosticv_config` or `agnosticd_code`, **MUST** include `github_path` in format `owner/repo:path/to/file.yml:line`
    - Extract GitHub paths from step4:

--- a/skills/root-cause-analysis/schemas/summary.schema.json
+++ b/skills/root-cause-analysis/schemas/summary.schema.json
@@ -31,7 +31,15 @@
             "resource",
             "cloud_api",
             "secrets",
-            "unknown"
+            "unknown",
+            "platform_failure",
+            "connectivity_failure",
+            "authentication_failure",
+            "resource_failure",
+            "timeout_failure",
+            "automation_failure",
+            "infrastructure_failure",
+            "general_failure"
           ]
         },
         "confidence": {

--- a/skills/root-cause-analysis/scripts/classify.py
+++ b/skills/root-cause-analysis/scripts/classify.py
@@ -1,0 +1,168 @@
+"""Classify error messages against known failure patterns.
+
+Loads a curated YAML file of regex-based error patterns and matches them
+against error messages from RCA steps 1 and 3. The YAML file can be
+provided via URL, local file path, or CLI flags.
+
+Configuration (in .claude/settings.local.json env block):
+  KNOWN_FAILED_YAML_URL — URL to fetch the YAML file (cached locally)
+  KNOWN_FAILED_YAML     — local file path (fallback)
+"""
+
+import os
+import re
+import tempfile
+from pathlib import Path
+
+import requests
+import yaml
+
+# Cache dir for downloaded known_failed.yaml
+_CACHE_DIR = Path(tempfile.gettempdir()) / "rhdp-rca"
+_CACHE_FILE = _CACHE_DIR / "known_failed.yaml"
+
+
+def fetch_known_failures_from_url(url: str) -> list[dict]:
+    """Fetch known failure patterns YAML from a URL.
+
+    Caches the file locally. Returns the parsed failures list.
+    """
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    headers = {}
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    if github_token and "api.github.com" in url:
+        headers["Authorization"] = f"token {github_token}"
+        headers["Accept"] = "application/vnd.github.v3.raw"
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        _CACHE_FILE.write_text(resp.text)
+        return _parse_yaml_content(resp.text)
+    except (requests.RequestException, yaml.YAMLError) as e:
+        # Fall back to cache if fetch fails
+        if _CACHE_FILE.exists():
+            return load_known_failures(_CACHE_FILE)
+        print(f"  Warning: Failed to fetch known failure patterns: {e}")
+        return []
+
+
+def load_known_failures(yaml_path: str | Path) -> list[dict]:
+    """Load known failure patterns from a local YAML file."""
+    path = Path(yaml_path)
+    if not path.exists():
+        return []
+    try:
+        with open(path) as f:
+            return _parse_yaml_content(f.read())
+    except (yaml.YAMLError, OSError):
+        return []
+
+
+def _parse_yaml_content(content: str) -> list[dict]:
+    """Parse YAML content and extract the failures list."""
+    data = yaml.safe_load(content)
+    if not data:
+        return []
+    return data.get("failures", [])
+
+
+def classify_error(error_message: str, known_failures: list[dict]) -> dict | None:
+    """Match an error message against known failure patterns.
+
+    Returns a dict with classification info on match, or None.
+    """
+    if not error_message or not known_failures:
+        return None
+
+    error_message = error_message.strip()
+
+    for failure in known_failures:
+        pattern = failure.get("error_string", "")
+        if not pattern:
+            continue
+        try:
+            if re.search(pattern, error_message, re.IGNORECASE | re.DOTALL):
+                return {
+                    "error_category": failure.get("category", "general_failure"),
+                    "matched_pattern": pattern,
+                    "failure_description": failure.get("description", ""),
+                }
+        except re.error:
+            continue
+
+    return None
+
+
+def classify_job_errors(
+    job_context: dict, correlation: dict, known_failures: list[dict]
+) -> list[dict]:
+    """Classify all error messages found in step1 and step3 outputs.
+
+    Returns a list of classification results (one per matched error).
+    """
+    results: list[dict] = []
+    seen_messages: set[str] = set()
+
+    # Collect error messages from step1 failed tasks
+    for task in job_context.get("failed_tasks", []):
+        msg = task.get("error_message", "")
+        if msg and msg not in seen_messages:
+            seen_messages.add(msg)
+            match = classify_error(msg, known_failures)
+            if match:
+                match["source"] = "aap_failed_task"
+                match["task"] = task.get("task", "")
+                results.append(match)
+
+    # Collect error messages from step3 timeline events
+    # Timeline events store messages in details.message (for aap_job) or
+    # details.message (for splunk_ocp), not at the top level.
+    for event in correlation.get("timeline_events", []):
+        details = event.get("details", {})
+        msg = details.get("message", "") or details.get("error_message", "")
+        if msg and msg not in seen_messages:
+            seen_messages.add(msg)
+            match = classify_error(msg, known_failures)
+            if match:
+                match["source"] = "correlation_timeline"
+                results.append(match)
+
+    return results
+
+
+def resolve_known_failures(
+    url: str | None = None, local_path: str | None = None
+) -> list[dict]:
+    """Resolve and load known failure patterns.
+
+    Args:
+        url: URL to fetch YAML from (overrides env var)
+        local_path: Local file path (overrides env var)
+
+    Priority:
+    1. Explicit url/local_path arguments (from CLI flags)
+    2. KNOWN_FAILED_YAML_URL env var — fetch from URL (cached locally)
+    3. KNOWN_FAILED_YAML env var — read from local file path
+    4. Returns empty list if none configured
+    """
+    # CLI flag: URL
+    if url:
+        return fetch_known_failures_from_url(url)
+
+    # CLI flag: local path
+    if local_path:
+        return load_known_failures(local_path)
+
+    # Env var: URL
+    env_url = os.environ.get("KNOWN_FAILED_YAML_URL", "")
+    if env_url:
+        return fetch_known_failures_from_url(env_url)
+
+    # Env var: local path
+    env_path = os.environ.get("KNOWN_FAILED_YAML", "")
+    if env_path:
+        return load_known_failures(env_path)
+
+    return []

--- a/skills/root-cause-analysis/scripts/classify.py
+++ b/skills/root-cause-analysis/scripts/classify.py
@@ -133,9 +133,7 @@ def classify_job_errors(
     return results
 
 
-def resolve_known_failures(
-    url: str | None = None, local_path: str | None = None
-) -> list[dict]:
+def resolve_known_failures(url: str | None = None, local_path: str | None = None) -> list[dict]:
     """Resolve and load known failure patterns.
 
     Args:

--- a/skills/root-cause-analysis/scripts/classify.py
+++ b/skills/root-cause-analysis/scripts/classify.py
@@ -64,9 +64,12 @@ def load_known_failures(yaml_path: str | Path) -> list[dict]:
 def _parse_yaml_content(content: str) -> list[dict]:
     """Parse YAML content and extract the failures list."""
     data = yaml.safe_load(content)
-    if not data:
+    if not isinstance(data, dict):
         return []
-    return data.get("failures", [])
+    failures = data.get("failures", [])
+    if not isinstance(failures, list):
+        return []
+    return [f for f in failures if isinstance(f, dict)]
 
 
 def classify_error(error_message: str, known_failures: list[dict]) -> dict | None:

--- a/skills/root-cause-analysis/scripts/classify.py
+++ b/skills/root-cause-analysis/scripts/classify.py
@@ -14,7 +14,6 @@ import re
 import tempfile
 from pathlib import Path
 
-import requests
 import yaml
 
 # Cache dir for downloaded known_failed.yaml
@@ -28,6 +27,8 @@ def fetch_known_failures_from_url(url: str) -> list[dict]:
     Caches the file locally. Returns the parsed failures list.
     """
     _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    import requests
 
     headers = {}
     github_token = os.environ.get("GITHUB_TOKEN", "")

--- a/skills/root-cause-analysis/scripts/classify.py
+++ b/skills/root-cause-analysis/scripts/classify.py
@@ -1,14 +1,22 @@
 """Classify error messages against known failure patterns.
 
 Loads a curated YAML file of regex-based error patterns and matches them
-against error messages from RCA steps 1 and 3. The YAML file can be
-provided via URL, local file path, or CLI flags.
+against error messages from RCA steps 1 and 3. The pattern source is fully
+optional and can be provided three ways, none of which require a GitHub token:
 
-Configuration (in .claude/settings.local.json env block):
-  KNOWN_FAILED_YAML_URL — URL to fetch the YAML file (cached locally)
-  KNOWN_FAILED_YAML     — local file path (fallback)
+  * ``--known-failures-file`` / ``KNOWN_FAILED_YAML`` — a local file path
+  * ``--known-failures-url`` / ``KNOWN_FAILED_YAML_URL`` — any HTTP(S) URL,
+    including a plain raw URL fetched over ``curl``/HTTP with no credentials
+    (e.g. https://raw.githubusercontent.com/<owner>/<repo>/<branch>/known_failed.yaml)
+
+A ``GITHUB_TOKEN`` is only used to authenticate private ``api.github.com``
+repositories; when it is absent the request is still made. When no source is
+configured at all, classification is skipped gracefully (zero patterns loaded).
 """
 
+import base64
+import hashlib
+import json
 import os
 import re
 import tempfile
@@ -16,35 +24,56 @@ from pathlib import Path
 
 import yaml
 
-# Cache dir for downloaded known_failed.yaml
+# Cache dir for downloaded known_failed.yaml files. Each source URL gets its
+# own cache file (keyed by a hash of the URL) so a failed fetch for one URL
+# never reuses patterns cached from a different URL.
 _CACHE_DIR = Path(tempfile.gettempdir()) / "rhdp-rca"
-_CACHE_FILE = _CACHE_DIR / "known_failed.yaml"
+
+
+def _cache_path_for(url: str) -> Path:
+    """Return a per-URL cache file path so caches never cross sources."""
+    digest = hashlib.sha256(url.encode("utf-8")).hexdigest()[:16]
+    return _CACHE_DIR / f"known_failed_{digest}.yaml"
 
 
 def fetch_known_failures_from_url(url: str) -> list[dict]:
     """Fetch known failure patterns YAML from a URL.
 
-    Caches the file locally. Returns the parsed failures list.
+    Works with a plain raw URL (e.g. raw.githubusercontent.com) fetched over
+    HTTP with no credentials, as well as ``api.github.com/.../contents`` URLs.
+    A ``GITHUB_TOKEN`` is optional and only used to authenticate private
+    repositories; when it is absent the request is still made and the raw
+    ``Accept`` header is sent so GitHub returns file content rather than JSON
+    metadata.
+
+    Caches the file locally, keyed by URL so a failed fetch never falls back to
+    patterns cached from a different source. Returns the parsed failures list.
     """
     _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    cache_file = _cache_path_for(url)
 
     import requests
 
     headers = {}
-    github_token = os.environ.get("GITHUB_TOKEN", "")
-    if github_token and "api.github.com" in url:
-        headers["Authorization"] = f"token {github_token}"
+    is_github_api = "api.github.com" in url
+    if is_github_api:
+        # Request raw content even without a token; unauthenticated
+        # api.github.com/contents requests otherwise return JSON metadata.
         headers["Accept"] = "application/vnd.github.v3.raw"
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    if github_token and is_github_api:
+        headers["Authorization"] = f"token {github_token}"
 
     try:
         resp = requests.get(url, headers=headers, timeout=15)
         resp.raise_for_status()
-        _CACHE_FILE.write_text(resp.text)
-        return _parse_yaml_content(resp.text)
+        content = _extract_yaml_text(resp.text)
+        cache_file.write_text(content)
+        return _parse_yaml_content(content)
     except (requests.RequestException, yaml.YAMLError) as e:
-        # Fall back to cache if fetch fails
-        if _CACHE_FILE.exists():
-            return load_known_failures(_CACHE_FILE)
+        # Fall back only to this URL's own cache, never another source's.
+        if cache_file.exists():
+            return load_known_failures(cache_file)
         print(f"  Warning: Failed to fetch known failure patterns: {e}")
         return []
 
@@ -59,6 +88,29 @@ def load_known_failures(yaml_path: str | Path) -> list[dict]:
             return _parse_yaml_content(f.read())
     except (yaml.YAMLError, OSError):
         return []
+
+
+def _extract_yaml_text(text: str) -> str:
+    """Return raw YAML text, decoding GitHub JSON metadata if necessary.
+
+    A plain raw URL returns YAML directly. If an ``api.github.com/contents``
+    request is served as JSON metadata (e.g. the raw ``Accept`` header was
+    ignored on an unauthenticated request), decode the base64 ``content`` field
+    so the caller always receives YAML instead of silently parsing zero
+    patterns from the metadata envelope.
+    """
+    if not text.lstrip().startswith("{"):
+        return text
+    try:
+        meta = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return text
+    if isinstance(meta, dict) and meta.get("encoding") == "base64" and "content" in meta:
+        try:
+            return base64.b64decode(meta["content"]).decode("utf-8")
+        except (ValueError, UnicodeDecodeError):
+            return text
+    return text
 
 
 def _parse_yaml_content(content: str) -> list[dict]:
@@ -120,12 +172,17 @@ def classify_job_errors(
                 match["task"] = task.get("task", "")
                 results.append(match)
 
-    # Collect error messages from step3 timeline events
-    # Timeline events store messages in details.message (for aap_job) or
-    # details.message (for splunk_ocp), not at the top level.
+    # Collect error messages from step3 timeline events. build_correlation_timeline()
+    # stores the log text under details.message (splunk_ocp / pod & Splunk logs) or
+    # details.error_message (aap_job). Fall back to a top-level message key so text
+    # that only surfaces in pod/Splunk logs is still classified.
     for event in correlation.get("timeline_events", []):
         details = event.get("details", {})
-        msg = details.get("message", "") or details.get("error_message", "")
+        msg = (
+            details.get("message", "")
+            or details.get("error_message", "")
+            or event.get("message", "")
+        )
         if msg and msg not in seen_messages:
             seen_messages.add(msg)
             match = classify_error(msg, known_failures)

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 if __name__ == "__main__" and __package__ is None:
     # Running directly as scripts/cli.py - add parent to path
     sys.path.insert(0, str(Path(__file__).parent.parent))
+    from scripts.classify import classify_job_errors, resolve_known_failures
     from scripts.config import Config
     from scripts.correlator import build_correlation_timeline, fetch_correlated_logs
     from scripts.job_parser import parse_job_log
@@ -18,6 +19,7 @@ if __name__ == "__main__" and __package__ is None:
     from scripts.step4_fetch_github import GitHubClient, Step4Analyzer
 else:
     # Running as module (-m scripts.cli)
+    from .classify import classify_job_errors, resolve_known_failures
     from .config import Config
     from .correlator import build_correlation_timeline, fetch_correlated_logs
     from .job_parser import parse_job_log
@@ -204,6 +206,36 @@ def cmd_analyze(args: argparse.Namespace, config: Config) -> int:
             print(f"  Error fetching GitHub files: {e}")
             return 1
 
+    # Classify errors against known failure patterns (optional)
+    print("\n[Classify] Matching errors against known failure patterns...")
+    known_failures = resolve_known_failures(
+        url=getattr(args, "known_failures_url", None),
+        local_path=getattr(args, "known_failures_file", None),
+    )
+    classification_path = analysis_dir / "classification.json"
+    if known_failures:
+        classifications = classify_job_errors(job_context, correlation, known_failures)
+        classification_result = {
+            "patterns_loaded": len(known_failures),
+            "matches": classifications,
+        }
+        with open(classification_path, "w") as f:
+            json.dump(classification_result, f, indent=2)
+        if classifications:
+            print(f"  Matched {len(classifications)} error(s) against known patterns")
+            for c in classifications:
+                print(f"    - {c['error_category']}: {c['failure_description']}")
+        else:
+            print("  No matches — errors may be novel/unclassified")
+        print(f"  Output: {classification_path}")
+    else:
+        print("  Skipped: no known failure patterns configured (optional)")
+        print(
+            "  Hint: Use --known-failures-file <path> or --known-failures-url <url>,"
+            " or set KNOWN_FAILED_YAML_URL / KNOWN_FAILED_YAML"
+            " in .claude/settings.local.json env block"
+        )
+
     # Print summary
     print("\n" + "=" * 60)
     print("Analysis Complete")
@@ -355,6 +387,14 @@ def main():
         "--fetch",
         action="store_true",
         help="Fetch job log from remote server via SSH if not found locally",
+    )
+    analyze_parser.add_argument(
+        "--known-failures-url",
+        help="URL to fetch known_failed.yaml from (overrides KNOWN_FAILED_YAML_URL env var)",
+    )
+    analyze_parser.add_argument(
+        "--known-failures-file",
+        help="Local path to known_failed.yaml (overrides KNOWN_FAILED_YAML env var)",
     )
 
     # parse command

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -213,28 +213,31 @@ def cmd_analyze(args: argparse.Namespace, config: Config) -> int:
         local_path=getattr(args, "known_failures_file", None),
     )
     classification_path = analysis_dir / "classification.json"
+    classification_result: dict = {
+        "patterns_loaded": len(known_failures),
+        "matches": [],
+    }
     if known_failures:
         classifications = classify_job_errors(job_context, correlation, known_failures)
-        classification_result = {
-            "patterns_loaded": len(known_failures),
-            "matches": classifications,
-        }
-        with open(classification_path, "w") as f:
-            json.dump(classification_result, f, indent=2)
+        classification_result["matches"] = classifications
         if classifications:
             print(f"  Matched {len(classifications)} error(s) against known patterns")
             for c in classifications:
                 print(f"    - {c['error_category']}: {c['failure_description']}")
         else:
             print("  No matches — errors may be novel/unclassified")
-        print(f"  Output: {classification_path}")
     else:
+        classification_result["skipped"] = True
+        classification_result["reason"] = "no known failure patterns configured"
         print("  Skipped: no known failure patterns configured (optional)")
         print(
             "  Hint: Use --known-failures-file <path> or --known-failures-url <url>,"
             " or set KNOWN_FAILED_YAML_URL / KNOWN_FAILED_YAML"
             " in .claude/settings.local.json env block"
         )
+    with open(classification_path, "w") as f:
+        json.dump(classification_result, f, indent=2)
+    print(f"  Output: {classification_path}")
 
     # Print summary
     print("\n" + "=" * 60)

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -297,28 +297,31 @@ def cmd_analyze(args: argparse.Namespace, config: Config, span=None) -> int:
         local_path=getattr(args, "known_failures_file", None),
     )
     classification_path = analysis_dir / "classification.json"
+    classification_result: dict = {
+        "patterns_loaded": len(known_failures),
+        "matches": [],
+    }
     if known_failures:
         classifications = classify_job_errors(job_context, correlation, known_failures)
-        classification_result = {
-            "patterns_loaded": len(known_failures),
-            "matches": classifications,
-        }
-        with open(classification_path, "w") as f:
-            json.dump(classification_result, f, indent=2)
+        classification_result["matches"] = classifications
         if classifications:
             print(f"  Matched {len(classifications)} error(s) against known patterns")
             for c in classifications:
                 print(f"    - {c['error_category']}: {c['failure_description']}")
         else:
             print("  No matches — errors may be novel/unclassified")
-        print(f"  Output: {classification_path}")
     else:
+        classification_result["skipped"] = True
+        classification_result["reason"] = "no known failure patterns configured"
         print("  Skipped: no known failure patterns configured (optional)")
         print(
             "  Hint: Use --known-failures-file <path> or --known-failures-url <url>,"
             " or set KNOWN_FAILED_YAML_URL / KNOWN_FAILED_YAML"
             " in .claude/settings.local.json env block"
         )
+    with open(classification_path, "w") as f:
+        json.dump(classification_result, f, indent=2)
+    print(f"  Output: {classification_path}")
 
     # Print summary
     print("\n" + "=" * 60)

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -17,6 +17,7 @@ if __name__ == "__main__" and __package__ is None:
         resolve_bastion_for_job,
         resolve_remote_log_dir,
     )
+    from scripts.classify import classify_job_errors, resolve_known_failures
     from scripts.config import Config
     from scripts.correlator import build_correlation_timeline, fetch_correlated_logs
     from scripts.github_fetcher import GitHubAnalyzer, GitHubClient
@@ -32,6 +33,7 @@ else:
         resolve_bastion_for_job,
         resolve_remote_log_dir,
     )
+    from .classify import classify_job_errors, resolve_known_failures
     from .config import Config
     from .correlator import build_correlation_timeline, fetch_correlated_logs
     from .github_fetcher import GitHubAnalyzer, GitHubClient
@@ -288,6 +290,36 @@ def cmd_analyze(args: argparse.Namespace, config: Config, span=None) -> int:
                 span.set_outputs({"error": error_message})
             return 1
 
+    # Classify errors against known failure patterns (optional)
+    print("\n[Classify] Matching errors against known failure patterns...")
+    known_failures = resolve_known_failures(
+        url=getattr(args, "known_failures_url", None),
+        local_path=getattr(args, "known_failures_file", None),
+    )
+    classification_path = analysis_dir / "classification.json"
+    if known_failures:
+        classifications = classify_job_errors(job_context, correlation, known_failures)
+        classification_result = {
+            "patterns_loaded": len(known_failures),
+            "matches": classifications,
+        }
+        with open(classification_path, "w") as f:
+            json.dump(classification_result, f, indent=2)
+        if classifications:
+            print(f"  Matched {len(classifications)} error(s) against known patterns")
+            for c in classifications:
+                print(f"    - {c['error_category']}: {c['failure_description']}")
+        else:
+            print("  No matches — errors may be novel/unclassified")
+        print(f"  Output: {classification_path}")
+    else:
+        print("  Skipped: no known failure patterns configured (optional)")
+        print(
+            "  Hint: Use --known-failures-file <path> or --known-failures-url <url>,"
+            " or set KNOWN_FAILED_YAML_URL / KNOWN_FAILED_YAML"
+            " in .claude/settings.local.json env block"
+        )
+
     # Print summary
     print("\n" + "=" * 60)
     print("Analysis Complete")
@@ -498,6 +530,14 @@ def main() -> int:
         "--fetch",
         action="store_true",
         help="Fetch job log from remote server via SSH if not found locally",
+    )
+    analyze_parser.add_argument(
+        "--known-failures-url",
+        help="URL to fetch known_failed.yaml from (overrides KNOWN_FAILED_YAML_URL env var)",
+    )
+    analyze_parser.add_argument(
+        "--known-failures-file",
+        help="Local path to known_failed.yaml (overrides KNOWN_FAILED_YAML env var)",
     )
 
     # parse command

--- a/skills/root-cause-analysis/tests/test_classify.py
+++ b/skills/root-cause-analysis/tests/test_classify.py
@@ -1,0 +1,157 @@
+"""Tests for classify.py — known failure pattern matching."""
+
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from scripts.classify import classify_error, classify_job_errors, load_known_failures
+
+
+SAMPLE_FAILURES = [
+    {
+        "error_string": "Shared connection to.*compute.amazonaws.com closed",
+        "description": "Unable to reach bastion host",
+        "category": "connectivity_failure",
+    },
+    {
+        "error_string": "Bootstrap failed to complete: timed out waiting for the condition",
+        "description": "OpenShift Installer failed due to cloud timeout",
+        "category": "timeout_failure",
+    },
+    {
+        "error_string": "MODULE FAILURE",
+        "description": "Ansible module failure",
+        "category": "automation_failure",
+    },
+]
+
+
+def _write_yaml(tmp_dir: Path, failures: list[dict]) -> Path:
+    path = tmp_dir / "known_failed.yaml"
+    with open(path, "w") as f:
+        yaml.dump({"failures": failures}, f)
+    return path
+
+
+def test_load_known_failures_valid():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = _write_yaml(Path(tmp), SAMPLE_FAILURES)
+        failures = load_known_failures(path)
+        assert len(failures) == 3
+
+
+def test_load_known_failures_missing_file():
+    failures = load_known_failures("/nonexistent/path.yaml")
+    assert failures == []
+
+
+def test_load_known_failures_empty_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "empty.yaml"
+        path.write_text("")
+        failures = load_known_failures(path)
+        assert failures == []
+
+
+def test_classify_error_match():
+    result = classify_error(
+        "Shared connection to ec2-1-2-3-4.compute.amazonaws.com closed",
+        SAMPLE_FAILURES,
+    )
+    assert result is not None
+    assert result["error_category"] == "connectivity_failure"
+    assert result["failure_description"] == "Unable to reach bastion host"
+
+
+def test_classify_error_no_match():
+    result = classify_error("Some completely unknown error", SAMPLE_FAILURES)
+    assert result is None
+
+
+def test_classify_error_empty_message():
+    result = classify_error("", SAMPLE_FAILURES)
+    assert result is None
+
+
+def test_classify_error_empty_patterns():
+    result = classify_error("MODULE FAILURE", [])
+    assert result is None
+
+
+def test_classify_error_invalid_regex_skipped():
+    bad_patterns = [
+        {"error_string": "[invalid(regex", "description": "bad", "category": "x"},
+        {"error_string": "MODULE FAILURE", "description": "ok", "category": "automation_failure"},
+    ]
+    result = classify_error("MODULE FAILURE", bad_patterns)
+    assert result is not None
+    assert result["error_category"] == "automation_failure"
+
+
+def test_classify_job_errors_reads_details_message():
+    """Timeline events store messages in details.message, not top-level message."""
+    job_context = {
+        "failed_tasks": [
+            {
+                "task": "Connect to bastion",
+                "error_message": "Shared connection to ec2-1-2-3.compute.amazonaws.com closed",
+            },
+        ]
+    }
+    # Matches real build_correlation_timeline() output structure:
+    # aap_job events have details.error_message
+    # splunk_ocp events have details.message
+    correlation = {
+        "timeline_events": [
+            {
+                "source": "aap_job",
+                "event_type": "task_failed",
+                "summary": "Task 'Run module' failed",
+                "details": {"task": "Run module", "error_message": "MODULE FAILURE"},
+            },
+            {
+                "source": "splunk_ocp",
+                "event_type": "pod_error",
+                "summary": "Error in pod 'installer-xyz'",
+                "details": {
+                    "pod_name": "installer-xyz",
+                    "message": "Bootstrap failed to complete: timed out waiting for the condition",
+                },
+            },
+        ]
+    }
+    results = classify_job_errors(job_context, correlation, SAMPLE_FAILURES)
+    assert len(results) == 3
+    categories = {r["error_category"] for r in results}
+    assert categories == {"connectivity_failure", "automation_failure", "timeout_failure"}
+
+
+def test_classify_job_errors_deduplicates():
+    """Same error in step1 and step3 should only appear once."""
+    job_context = {
+        "failed_tasks": [
+            {"task": "Run module", "error_message": "MODULE FAILURE"},
+        ]
+    }
+    correlation = {
+        "timeline_events": [
+            {
+                "source": "aap_job",
+                "details": {"error_message": "MODULE FAILURE"},
+            },
+        ]
+    }
+    results = classify_job_errors(job_context, correlation, SAMPLE_FAILURES)
+    assert len(results) == 1
+    assert results[0]["error_category"] == "automation_failure"
+
+
+def test_classify_job_errors_empty_inputs():
+    """No errors should produce empty results, not crash."""
+    results = classify_job_errors({}, {}, SAMPLE_FAILURES)
+    assert results == []
+    results = classify_job_errors({"failed_tasks": []}, {"timeline_events": []}, SAMPLE_FAILURES)
+    assert results == []
+    results = classify_job_errors({"failed_tasks": []}, {"timeline_events": []}, [])
+    assert results == []

--- a/skills/root-cause-analysis/tests/test_classify.py
+++ b/skills/root-cause-analysis/tests/test_classify.py
@@ -7,7 +7,6 @@ import yaml
 
 from scripts.classify import classify_error, classify_job_errors, load_known_failures
 
-
 SAMPLE_FAILURES = [
     {
         "error_string": "Shared connection to.*compute.amazonaws.com closed",

--- a/skills/root-cause-analysis/tests/test_classify.py
+++ b/skills/root-cause-analysis/tests/test_classify.py
@@ -1,11 +1,19 @@
 """Tests for classify.py — known failure pattern matching."""
 
+import base64
+import json
 import tempfile
 from pathlib import Path
 
 import yaml
 
-from scripts.classify import classify_error, classify_job_errors, load_known_failures
+from scripts.classify import (
+    _cache_path_for,
+    _extract_yaml_text,
+    classify_error,
+    classify_job_errors,
+    load_known_failures,
+)
 
 SAMPLE_FAILURES = [
     {
@@ -124,6 +132,46 @@ def test_classify_job_errors_reads_details_message():
     assert len(results) == 3
     categories = {r["error_category"] for r in results}
     assert categories == {"connectivity_failure", "automation_failure", "timeout_failure"}
+
+
+def test_classify_job_errors_reads_top_level_message():
+    """A top-level message on a timeline event is classified as a fallback."""
+    correlation = {
+        "timeline_events": [
+            {"source": "splunk_ocp", "message": "MODULE FAILURE"},
+        ]
+    }
+    results = classify_job_errors({}, correlation, SAMPLE_FAILURES)
+    assert len(results) == 1
+    assert results[0]["error_category"] == "automation_failure"
+
+
+def test_extract_yaml_text_passthrough_for_raw():
+    """Plain raw YAML (from curl / raw.githubusercontent.com) is returned as-is."""
+    raw = "failures:\n  - error_string: MODULE FAILURE\n"
+    assert _extract_yaml_text(raw) == raw
+
+
+def test_extract_yaml_text_decodes_github_metadata():
+    """GitHub contents-API JSON metadata is decoded to its underlying YAML."""
+    yaml_body = "failures:\n  - error_string: MODULE FAILURE\n    category: automation_failure\n"
+    metadata = json.dumps(
+        {
+            "name": "known_failed.yaml",
+            "encoding": "base64",
+            "content": base64.b64encode(yaml_body.encode()).decode(),
+        }
+    )
+    assert _extract_yaml_text(metadata) == yaml_body
+
+
+def test_cache_path_is_scoped_per_url():
+    """Different URLs must resolve to different cache files (no cross-source reuse)."""
+    a = _cache_path_for("https://raw.example.test/a/known_failed.yaml")
+    b = _cache_path_for("https://raw.example.test/b/known_failed.yaml")
+    assert a != b
+    # Same URL is stable across calls.
+    assert a == _cache_path_for("https://raw.example.test/a/known_failed.yaml")
 
 
 def test_classify_job_errors_deduplicates():


### PR DESCRIPTION
## What

Adds an optional classification step between Step 4 and Step 5. Job errors are regex-matched against a curated `known_failed.yaml` and the result is written to `classification.json`, so Step 5 reads verified categories — the same taxonomy as the RHDP ETL pipeline — instead of Claude guessing them.

Fully optional: with no pattern source configured the step is skipped, `classification.json` records `"skipped": true`, and nothing else in the pipeline changes.

## Pattern source

Any one of, in priority order — no GitHub token required:

- `--known-failures-url` / `KNOWN_FAILED_YAML_URL` — any HTTP(S) URL; a plain `raw.githubusercontent.com` URL works unauthenticated
- `--known-failures-file` / `KNOWN_FAILED_YAML` — local path

`GITHUB_TOKEN` is used only to reach private `api.github.com` URLs. Downloads are cached per-URL (keyed by hash), so a failed fetch never silently falls back to a different source's cache.

## Files

- `scripts/classify.py` — new; load, cache, match
- `scripts/cli.py` — wires the step in after Step 4, adds the two flags
- `SKILL.md`, `README.md` — instruct Claude to prefer verified categories
- `schemas/summary.schema.json` — additional failure-specific categories
- `tests/test_classify.py` — new; 15 tests

## Verification

- [x] `pytest` 76 passed (61 existing + 15 new); `ruff check` + `ruff format --check` clean; no new `mypy` errors vs `main`
- [x] Rebased on `main` @ 25d62cf — conflict-free
- [ ] Run against a real failed job and confirm Step 5 consumes the categories

## Reviewer note

This is complementary to `deploy/batch-rca-automation/scripts/fetch_known_issues.py`, which surfaces *learned* history (prior high-confidence results from Postgres). This PR supplies a *curated* ground-truth taxonomy. If you'd rather have one front door for "verified categories", say so and I'll align them.
