### PR TITLE
Run 'Claude' only solution

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -18,22 +18,34 @@
     "MLFLOW_TAG_USER": "<your-username>"
   },
   "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
-          }
-        ]
-      }
-    ],
     "SessionStart": [
       {
         "hooks": [
           {
             "type": "command",
             "command": "INPUT=$(cat); SESSION_ID=$(echo \"$INPUT\" | jq -r '.session_id'); echo \"export CLAUDE_SESSION_ID='$SESSION_ID'\" >> \"$CLAUDE_ENV_FILE\""
+          },
+          {
+            "type": "command",
+            "command": "ssh -f -N -L $MLFLOW_PORT:localhost:5000 $JUMPBOX_URI"
+          },
+          {
+            "type": "command",
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
+          },
+          {
+            "type": "command",
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude -u http://127.0.0.1:$MLFLOW_PORT -n $MLFLOW_EXPERIMENT_NAME; fi"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
           }
         ]
       }

--- a/skills/feedback-capture/scripts/utils.py
+++ b/skills/feedback-capture/scripts/utils.py
@@ -84,7 +84,7 @@ def upload_feedback_to_jumpbox(
     ssh_cmd = ["ssh"]
     if ssh_port:
         ssh_cmd.extend(["-p", ssh_port])
-    ssh_cmd.extend([ssh_target, "mkdir -p /tmp"])
+    ssh_cmd.extend([ssh_target, "mkdir -p /usr/local/mlflow"])
 
     try:
         subprocess.run(
@@ -105,7 +105,7 @@ def upload_feedback_to_jumpbox(
                 scp_cmd.extend(["-P", ssh_port])
 
             dest_filename = f"feedback_{session_id}.json" if session_id else feedback_file.name
-            scp_cmd.extend([str(feedback_file), f"{ssh_target}:/tmp/{dest_filename}"])
+            scp_cmd.extend([str(feedback_file), f"{ssh_target}:/usr/local/mlflow/{dest_filename}"])
 
             subprocess.run(
                 scp_cmd,
@@ -113,7 +113,9 @@ def upload_feedback_to_jumpbox(
                 capture_output=True,
                 timeout=30,
             )
-            print(f"  Uploaded feedback to Jumpbox ({ssh_target}): /tmp/{dest_filename}")
+            print(
+                f"  Uploaded feedback to Jumpbox ({ssh_target}): /usr/local/mlflow/{dest_filename}"
+            )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             print(f"  Error uploading feedback: {e}")
             return False
@@ -124,7 +126,7 @@ def upload_feedback_to_jumpbox(
             scp_cmd = ["scp"]
             if ssh_port:
                 scp_cmd.extend(["-P", ssh_port])
-            scp_cmd.extend([str(chat_history_file), f"{ssh_target}:/tmp/"])
+            scp_cmd.extend([str(chat_history_file), f"{ssh_target}:/usr/local/mlflow/"])
 
             subprocess.run(
                 scp_cmd,
@@ -133,7 +135,7 @@ def upload_feedback_to_jumpbox(
                 timeout=30,
             )
             print(
-                f"  Uploaded chat history to Jumpbox ({ssh_target}): /tmp/{chat_history_file.name}"
+                f"  Uploaded chat history to Jumpbox ({ssh_target}): /usr/local/mlflow/{chat_history_file.name}"
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             print(f"  Warning: Could not upload chat history: {e}")

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -64,8 +64,29 @@ If any checks have `"status": "missing"` and `"configurable": true`, offer to he
 6. If MLflow env vars were configured (MLFLOW_PORT, MLFLOW_EXPERIMENT_NAME), also add the required MLflow hooks to the `"hooks"` block (create it if it doesn't exist):
    ```json
    "hooks": {
-     "Stop": [{ "hooks": [{ "type": "command", "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\"" }] }],
-     "SessionStart": [{ "hooks": [{ "type": "command", "command": "INPUT=$(cat); SESSION_ID=$(echo \"$INPUT\" | jq -r '.session_id'); echo \"export CLAUDE_SESSION_ID='$SESSION_ID'\" >> \"$CLAUDE_ENV_FILE\"" }] }]
+     "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); SESSION_ID=$(echo \"$INPUT\" | jq -r '.session_id'); echo \"export CLAUDE_SESSION_ID='$SESSION_ID'\" >> \"$CLAUDE_ENV_FILE\""
+          },
+          {
+            "type": "command",
+            "command": "if ! lsof -iTCP:$MLFLOW_PORT -sTCP:LISTEN >/dev/null 2>&1; then ssh -f -N -o ExitOnForwardFailure=yes -L $MLFLOW_PORT:localhost:5000 $JUMPBOX_URI; fi"
+          },
+          {
+            "type": "command",
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
+          },
+          {
+            "type": "command",
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude -u http://127.0.0.1:$MLFLOW_PORT -n $MLFLOW_EXPERIMENT_NAME; fi"
+          }
+        ]
+      }
+    ],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\"" }] }],
    }
    ```
 7. Write the updated settings file

--- a/skills/root-cause-analysis/scripts/cli.py
+++ b/skills/root-cause-analysis/scripts/cli.py
@@ -48,7 +48,7 @@ def save_step(analysis_dir: Path, step: int, data: dict) -> Path:
 
 @trace(name="Upload analysis", span_type=SpanType.CHAIN if SpanType else None)
 def upload_analysis_to_jumpbox(args: argparse.Namespace, config: Config, span=None) -> int:
-    """Upload analysis directory to Jumpbox in /tmp/{job_id}/ with session.json."""
+    """Upload analysis directory to Jumpbox in /usr/local/mlflow/{job_id}/ with session.json."""
     analysis_dir = config.analysis_dir / args.job_id
 
     if not analysis_dir.exists():
@@ -84,7 +84,7 @@ def upload_analysis_to_jumpbox(args: argparse.Namespace, config: Config, span=No
 
     session_id = os.environ.get("CLAUDE_SESSION_ID", "unknown")
     job_id = args.job_id
-    remote_base_dir = f"/tmp/{job_id}"
+    remote_base_dir = f"/usr/local/mlflow/{job_id}"
 
     # Create session.json file locally (will be overwritten if exists)
     session_file = analysis_dir / "session.json"


### PR DESCRIPTION
Note: Required to set envs
Enables tunnelling to jumpbox
If TRACING_ENABLED == true then MLFOW runs.
All run in the settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session startup now exports the session ID, ensures an SSH local port-forward is available, and optionally installs/enables MLflow autologging to a local endpoint when tracing is enabled.
  * Session stop behavior adjusted to preserve session ID on shutdown.

* **Chores**
  * Feedback and analysis uploads now target a persistent central directory on the remote host; related success messages updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->