### PR TITLE
Extract stdout/stderr/cmd/rc from failed tasks in step1 parser

### DIFF
--- a/skills/root-cause-analysis/schemas/job_context.schema.json
+++ b/skills/root-cause-analysis/schemas/job_context.schema.json
@@ -66,7 +66,11 @@
           "error_message": {"type": "string"},
           "task_path": {"type": "string"},
           "task_action": {"type": "string"},
-          "duration": {"type": "number"}
+          "duration": {"type": "number"},
+          "stdout": {"type": ["string", "array"], "description": "stdout from the failed task result or event"},
+          "stderr": {"type": "string", "description": "stderr from the failed task result"},
+          "cmd": {"type": ["string", "array"], "description": "Command that was executed"},
+          "rc": {"type": "integer", "description": "Return code of the failed command"}
         }
       }
     },

--- a/skills/root-cause-analysis/scripts/job_parser.py
+++ b/skills/root-cause-analysis/scripts/job_parser.py
@@ -156,6 +156,27 @@ def _extract_pod_references(events: list[dict]) -> list[dict[str, str]]:
     return pod_refs
 
 
+def _parse_result_from_rendered_output(rendered: str) -> dict[str, Any] | None:
+    """Parse structured result fields from ANSI-rendered Ansible output.
+
+    When res fields are suppressed (e.g. _ansible_no_log), the diagnostic
+    data may still be available in the rendered event.stdout as a JSON blob
+    after 'FAILED! =>' or 'SUCCESS =>'.
+    """
+    # Strip ANSI escape codes
+    clean = re.sub(r"\x1b\[[0-9;]*m", "", rendered)
+    # Extract JSON blob after "=>"
+    match = re.search(r"=>\s*(\{.*\})\s*$", clean, re.DOTALL)
+    if match:
+        try:
+            result = json.loads(match.group(1))
+            if isinstance(result, dict):
+                return result
+        except (json.JSONDecodeError, ValueError):
+            pass
+    return None
+
+
 def _extract_failed_tasks(events: list[dict]) -> list[dict[str, Any]]:
     """Extract failed tasks with error details."""
     failed = []
@@ -183,11 +204,20 @@ def _extract_failed_tasks(events: list[dict]) -> list[dict[str, Any]]:
                     if value is not None and value != "":
                         task_info[field] = value
 
-            # Fallback: capture event-level stdout when res fields are missing
-            if "stdout" not in task_info:
+            # Fallback: parse structured fields from rendered event.stdout
+            # when res fields are suppressed (e.g. _ansible_no_log)
+            if "stdout" not in task_info or "stderr" not in task_info:
                 event_stdout = event.get("stdout", "")
                 if event_stdout:
-                    task_info["stdout"] = event_stdout
+                    parsed = _parse_result_from_rendered_output(event_stdout)
+                    if parsed:
+                        for field in ("stdout", "stderr", "cmd"):
+                            if field not in task_info and field in parsed:
+                                task_info[field] = parsed[field]
+
+                    # Final fallback: raw event stdout if nothing was parsed
+                    if "stdout" not in task_info:
+                        task_info["stdout"] = event_stdout
 
             failed.append(task_info)
 

--- a/skills/root-cause-analysis/scripts/job_parser.py
+++ b/skills/root-cause-analysis/scripts/job_parser.py
@@ -165,18 +165,31 @@ def _extract_failed_tasks(events: list[dict]) -> list[dict[str, Any]]:
             event_data = event.get("event_data", {})
             res = event_data.get("res", {})
 
-            failed.append(
-                {
-                    "task": event.get("task", ""),
-                    "play": event.get("play", ""),
-                    "role": event.get("role", ""),
-                    "timestamp": event.get("created", ""),
-                    "error_message": res.get("msg", "") if isinstance(res, dict) else str(res),
-                    "task_path": event_data.get("task_path", ""),
-                    "task_action": event_data.get("task_action", ""),
-                    "duration": event_data.get("duration", 0),
-                }
-            )
+            task_info = {
+                "task": event.get("task", ""),
+                "play": event.get("play", ""),
+                "role": event.get("role", ""),
+                "timestamp": event.get("created", ""),
+                "error_message": res.get("msg", "") if isinstance(res, dict) else str(res),
+                "task_path": event_data.get("task_path", ""),
+                "task_action": event_data.get("task_action", ""),
+                "duration": event_data.get("duration", 0),
+            }
+
+            # Extract diagnostic details from res when available
+            if isinstance(res, dict):
+                for field in ("stdout", "stderr", "cmd", "rc"):
+                    value = res.get(field)
+                    if value is not None and value != "":
+                        task_info[field] = value
+
+            # Fallback: capture event-level stdout when res fields are missing
+            if "stdout" not in task_info:
+                event_stdout = event.get("stdout", "")
+                if event_stdout:
+                    task_info["stdout"] = event_stdout
+
+            failed.append(task_info)
 
     return failed
 

--- a/skills/root-cause-analysis/tests/data/sample_job.json
+++ b/skills/root-cause-analysis/tests/data/sample_job.json
@@ -35,7 +35,11 @@
       "created": "2023-10-27T10:04:00Z",
       "event_data": {
         "res": {
-          "msg": "Package not found"
+          "msg": "Package not found",
+          "rc": 1,
+          "cmd": ["yum", "install", "-y", "missing-package"],
+          "stderr": "Error: No matching packages to install",
+          "stdout": ""
         },
         "task_action": "yum",
         "duration": 5.2,

--- a/skills/root-cause-analysis/tests/scripts/test_job_parser.py
+++ b/skills/root-cause-analysis/tests/scripts/test_job_parser.py
@@ -257,7 +257,10 @@ def test_extract_failed_tasks_with_diagnostic_fields():
     assert task["error_message"] == "non-zero return code"
     assert task["rc"] == 1
     assert task["cmd"] == ["git", "checkout", "cert-manager-fallback"]
-    assert task["stderr"] == "error: pathspec 'cert-manager-fallback' did not match any file(s) known to git"
+    assert (
+        task["stderr"]
+        == "error: pathspec 'cert-manager-fallback' did not match any file(s) known to git"
+    )
     # stdout is empty string in res, so should not be in task_info from res
     # but event has no stdout either, so stdout key should be absent
     assert "stdout" not in task

--- a/skills/root-cause-analysis/tests/scripts/test_job_parser.py
+++ b/skills/root-cause-analysis/tests/scripts/test_job_parser.py
@@ -202,6 +202,11 @@ def test_extract_failed_tasks_basic(sample_job_data):
     assert task["error_message"] == "Package not found"
     assert task["task_action"] == "yum"
     assert task["duration"] == 5.2
+    assert task["rc"] == 1
+    assert task["cmd"] == ["yum", "install", "-y", "missing-package"]
+    assert task["stderr"] == "Error: No matching packages to install"
+    # stdout in res is empty string, so it should not be included from res
+    assert "stdout" not in task or task.get("stdout") != ""
 
 
 def test_extract_failed_tasks_ignores_non_failures():
@@ -226,6 +231,77 @@ def test_extract_failed_tasks_string_res():
     ]
     failed = _extract_failed_tasks(events)
     assert failed[0]["error_message"] == "Simple error string"
+
+
+def test_extract_failed_tasks_with_diagnostic_fields():
+    """Test that stdout, stderr, cmd, and rc are extracted from res."""
+    events = [
+        {
+            "event": "runner_on_failed",
+            "failed": True,
+            "task": "Git checkout",
+            "event_data": {
+                "res": {
+                    "msg": "non-zero return code",
+                    "rc": 1,
+                    "cmd": ["git", "checkout", "cert-manager-fallback"],
+                    "stdout": "",
+                    "stderr": "error: pathspec 'cert-manager-fallback' did not match any file(s) known to git",
+                },
+            },
+        }
+    ]
+    failed = _extract_failed_tasks(events)
+    assert len(failed) == 1
+    task = failed[0]
+    assert task["error_message"] == "non-zero return code"
+    assert task["rc"] == 1
+    assert task["cmd"] == ["git", "checkout", "cert-manager-fallback"]
+    assert task["stderr"] == "error: pathspec 'cert-manager-fallback' did not match any file(s) known to git"
+    # stdout is empty string in res, so should not be in task_info from res
+    # but event has no stdout either, so stdout key should be absent
+    assert "stdout" not in task
+
+
+def test_extract_failed_tasks_event_stdout_fallback():
+    """Test fallback to event-level stdout when res has no stdout."""
+    events = [
+        {
+            "event": "runner_on_failed",
+            "failed": True,
+            "task": "Run script",
+            "stdout": "TASK [run_script] fatal: host unreachable",
+            "event_data": {
+                "res": {
+                    "msg": "Connection timed out",
+                },
+            },
+        }
+    ]
+    failed = _extract_failed_tasks(events)
+    assert len(failed) == 1
+    task = failed[0]
+    assert task["stdout"] == "TASK [run_script] fatal: host unreachable"
+
+
+def test_extract_failed_tasks_res_stdout_takes_priority():
+    """Test that res.stdout takes priority over event stdout."""
+    events = [
+        {
+            "event": "runner_on_failed",
+            "failed": True,
+            "task": "Run command",
+            "stdout": "rendered ansible output",
+            "event_data": {
+                "res": {
+                    "msg": "failed",
+                    "stdout": "actual command output from res",
+                },
+            },
+        }
+    ]
+    failed = _extract_failed_tasks(events)
+    assert failed[0]["stdout"] == "actual command output from res"
 
 
 def test_extract_failed_tasks_no_failures():


### PR DESCRIPTION
## What

The step-1 parser only captured `res.msg` from failed task events — usually just "non-zero return code", with the actual diagnostic left inside a raw ANSI blob. This extracts `res.stdout`, `res.stderr`, `res.cmd`, and `res.rc` when present.

Fallback for suppressed `res` fields (e.g. `_ansible_no_log`): parse the JSON object after `FAILED! =>` out of the rendered `event.stdout`. If that also fails, keep the raw `event.stdout` rather than dropping it.

Ref #15.

## Files

- `scripts/job_parser.py` — extraction plus the `_parse_result_from_rendered_output` fallback
- `schemas/job_context.schema.json` — the four new optional fields
- `tests/scripts/test_job_parser.py`, `tests/data/sample_job.json` — 3 new tests

## Verification

- [x] Re-ran Job 2035762: step 1 now emits structured `stdout` / `stderr` / `cmd` / `rc` instead of an ANSI blob
- [x] `pytest` 64 passed (61 existing + 3 new); `ruff check` + `ruff format --check` clean; no new `mypy` errors vs `main`
- [x] Rebased on `main` @ 25d62cf — conflict-free
