### PR TITLE
Add OpenShift deployment for running Claude Code RCA skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ htmlcov/
 .incidents/
 experiments/combine_rca_context/*/.analysis/
 experiments/combine_rca_context/*.xlsx
+
+# OpenShift runner secrets
+deploy/settings.json
+deploy/secrets.yaml

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:20-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    python3 \
+    python3-venv \
+    python3-pip \
+    openssh-client \
+    rsync \
+    jq \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code
+
+WORKDIR /workspace
+
+RUN mkdir -p /workspace/.config/gcloud /workspace/.claude \
+    && touch /workspace/.config/gcloud/application_default_credentials.json \
+    && chmod -R g+rwX /workspace \
+    && chgrp -R 0 /workspace
+
+ENV HOME=/workspace
+
+ENTRYPOINT ["/bin/bash"]

--- a/deploy/pod.yaml
+++ b/deploy/pod.yaml
@@ -1,0 +1,100 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: claude-rca-eval
+  labels:
+    app: claude-rca-eval
+spec:
+  restartPolicy: Never
+  initContainers:
+    - name: setup-ssh
+      image: image-registry.openshift-image-registry.svc:5000/claude-ci-test/claude-rca:latest
+      command: ["bash", "-c"]
+      args:
+        - |
+          mkdir -p /workspace/.ssh /workspace/.claude /workspace/.config/gcloud
+          cp /tmp/ssh-secret/id_ed25519 /workspace/.ssh/id_ed25519
+          chmod 600 /workspace/.ssh/id_ed25519
+          cat > /workspace/.ssh/config <<EOF
+          Host ci-bastion
+            HostName $(cat /tmp/ssh-secret/bastion-hostname)
+            User $(cat /tmp/ssh-secret/bastion-username)
+            Port $(cat /tmp/ssh-secret/bastion-port)
+            IdentityFile /workspace/.ssh/id_ed25519
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+
+          Host ci-jumpbox
+            HostName $(cat /tmp/ssh-secret/jumpbox-hostname)
+            User $(cat /tmp/ssh-secret/jumpbox-username)
+            Port $(cat /tmp/ssh-secret/jumpbox-port)
+            IdentityFile /workspace/.ssh/id_ed25519
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+          EOF
+          chmod 600 /workspace/.ssh/config
+          cp /tmp/claude-settings/settings.json /workspace/.claude/settings.json
+          cp /tmp/gcp-creds/application_default_credentials.json /workspace/.config/gcloud/application_default_credentials.json
+      volumeMounts:
+        - name: ssh-secret
+          mountPath: /tmp/ssh-secret
+          readOnly: true
+        - name: claude-settings
+          mountPath: /tmp/claude-settings
+          readOnly: true
+        - name: gcp-creds
+          mountPath: /tmp/gcp-creds
+          readOnly: true
+        - name: workspace
+          mountPath: /workspace
+  containers:
+    - name: claude
+      image: image-registry.openshift-image-registry.svc:5000/claude-ci-test/claude-rca:latest
+      command: ["sleep", "infinity"]
+      env:
+        - name: CLAUDE_CODE_USE_VERTEX
+          value: "1"
+        - name: CLOUD_ML_REGION
+          valueFrom:
+            secretKeyRef:
+              name: claude-vertex-creds
+              key: CLOUD_ML_REGION
+        - name: ANTHROPIC_VERTEX_PROJECT_ID
+          valueFrom:
+            secretKeyRef:
+              name: claude-vertex-creds
+              key: ANTHROPIC_VERTEX_PROJECT_ID
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: "/workspace/.config/gcloud/application_default_credentials.json"
+        - name: HOME
+          value: "/workspace"
+        - name: CLAUDE_CODE_ACCEPT_TOS
+          value: "true"
+      volumeMounts:
+        - name: workspace
+          mountPath: /workspace
+      resources:
+        requests:
+          memory: "512Mi"
+          cpu: "500m"
+        limits:
+          memory: "2Gi"
+          cpu: "2"
+  volumes:
+    - name: workspace
+      emptyDir: {}
+    - name: gcp-creds
+      secret:
+        secretName: claude-vertex-creds
+        items:
+          - key: gcp-credentials
+            path: application_default_credentials.json
+    - name: claude-settings
+      secret:
+        secretName: rca-skill-config
+        items:
+          - key: settings.json
+            path: settings.json
+    - name: ssh-secret
+      secret:
+        secretName: ci-ssh-key

--- a/deploy/run-eval.sh
+++ b/deploy/run-eval.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+POD_NAME="${POD_NAME:-claude-rca-eval}"
+REPO_URL="${REPO_URL:-https://github.com/redhat-et/rhdp-rca-plugin.git}"
+BRANCH="${BRANCH:-main}"
+
+ALLOWED_TOOLS=(
+  "Bash(python3*)" "Bash(python3 *)"
+  "Bash(.venv/bin/python *)" "Bash(.venv/bin/pip *)"
+  "Bash(mkdir *)" "Bash(mkdir -p *)"
+  "Bash(cp *)" "Bash(ls *)" "Bash(cat *)"
+  "Bash(ssh *)" "Bash(rsync *)" "Bash(chmod *)"
+  "Bash(gzip *)" "Bash(gunzip *)"
+  "Bash(head *)" "Bash(tail *)" "Bash(wc *)"
+  "Bash(find *)" "Bash(grep *)" "Bash(jq *)"
+  "Read" "Write" "Glob" "Grep"
+)
+
+usage() {
+  echo "Usage: $0 <prompt>"
+  echo ""
+  echo "Run a Claude Code prompt inside the OpenShift eval pod."
+  echo ""
+  echo "Examples:"
+  echo "  $0 'Investigate why job <JOB_ID> failed'"
+  echo "  $0 'Analyze the root cause of the failure in extracted_log/job_<JOB_ID>.json.gz.transform-processed'"
+  echo ""
+  echo "Environment variables:"
+  echo "  POD_NAME   Pod name (default: claude-rca-eval)"
+  echo "  REPO_URL   Git repo to clone (default: redhat-et/rhdp-rca-plugin)"
+  echo "  BRANCH     Branch to checkout (default: main)"
+  exit 1
+}
+
+if [ $# -eq 0 ]; then
+  usage
+fi
+
+PROMPT="$1"
+
+echo "==> Checking pod status..."
+oc wait "pod/${POD_NAME}" --for=condition=Ready --timeout=60s
+
+echo "==> Cloning repo (branch: ${BRANCH})..."
+oc exec "${POD_NAME}" -- bash -c \
+  "rm -rf /workspace/rhdp-rca-plugin && git clone --branch ${BRANCH} ${REPO_URL} /workspace/rhdp-rca-plugin"
+
+echo "==> Running eval..."
+oc exec "${POD_NAME}" -- bash -c \
+  "cd /workspace/rhdp-rca-plugin && claude -p '${PROMPT}' \
+    --allowedTools $(printf '"%s" ' "${ALLOWED_TOOLS[@]}") \
+    --output-format json"

--- a/deploy/secrets.yaml.template
+++ b/deploy/secrets.yaml.template
@@ -1,0 +1,56 @@
+##
+## Secret templates for the OpenShift runner.
+## Fill in the base64-encoded values and apply with: oc apply -f secrets.yaml
+## To encode a value: echo -n 'my-value' | base64
+## To encode a file:  base64 < /path/to/file
+##
+
+---
+# Vertex AI credentials for Claude Code
+apiVersion: v1
+kind: Secret
+metadata:
+  name: claude-vertex-creds
+type: Opaque
+data:
+  # echo -n 'global' | base64
+  CLOUD_ML_REGION: "<base64-encoded-region>"
+  # echo -n 'your-gcp-project-id' | base64
+  ANTHROPIC_VERTEX_PROJECT_ID: "<base64-encoded-project-id>"
+  # base64 < /path/to/application_default_credentials.json
+  gcp-credentials: "<base64-encoded-gcp-service-account-json>"
+
+---
+# Claude Code settings.json (contains Splunk, GitHub, SSH env vars and hooks)
+# Populate from .claude/settings.example.json with real values
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rca-skill-config
+type: Opaque
+data:
+  # base64 < settings.json
+  settings.json: "<base64-encoded-settings-json>"
+
+---
+# SSH key and connection details for bastion/jumpbox access
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ci-ssh-key
+type: Opaque
+data:
+  # base64 < ~/.ssh/claude-ci-key
+  id_ed25519: "<base64-encoded-private-key>"
+  # echo -n 'bastion.example.com' | base64
+  bastion-hostname: "<base64-encoded-hostname>"
+  # echo -n 'rhdp-rca-runner' | base64
+  bastion-username: "<base64-encoded-username>"
+  # echo -n '22' | base64
+  bastion-port: "<base64-encoded-port>"
+  # echo -n 'jumpbox.example.com' | base64
+  jumpbox-hostname: "<base64-encoded-hostname>"
+  # echo -n 'rhdp-rca-runner' | base64
+  jumpbox-username: "<base64-encoded-username>"
+  # echo -n '30361' | base64
+  jumpbox-port: "<base64-encoded-port>"


### PR DESCRIPTION
Dockerfile, pod spec, secret templates, and eval runner script for deploying the RCA skill on OpenShift with Vertex AI backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added containerized deployment infrastructure including a Docker image configuration built on Node 20 with development tools and Claude support.
  * Introduced Kubernetes pod manifest for orchestrated container deployment, featuring SSH key management and Google Cloud credential staging capabilities.
  * Added automated evaluation execution script and secrets template for managing sensitive credentials and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->