### PR TITLE
mlflow remote branch

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -12,9 +12,11 @@
     "SPLUNK_OCP_INFRA_INDEX": "<splunk-ocp-infra-index>",
     "SPLUNK_VERIFY_SSL": "false",
     "GITHUB_TOKEN": "<your-github-token>",
-    "MLFLOW_PORT": "<localhost-port>",
-    "MLFLOW_EXPERIMENT_NAME": "<your-experiment-name>",
+    "MLFLOW_EXPERIMENT_NAME": "rhdp-rca-plugin-traces",
     "MLFLOW_CLAUDE_TRACING_ENABLED": "true",
+    "MLFLOW_TRACKING_URI": "<mlflow-tracking-uri>",
+    "MLFLOW_TRACKING_USERNAME": "<username>",
+    "MLFLOW_TRACKING_PASSWORD": "<password>",
     "MLFLOW_TAG_USER": "<your-username>"
   },
   "hooks": {
@@ -27,15 +29,11 @@
           },
           {
             "type": "command",
-            "command": "ssh -f -N -L $MLFLOW_PORT:localhost:5000 $JUMPBOX_URI"
-          },
-          {
-            "type": "command",
             "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
           },
           {
             "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then python3 -c \"import mlflow; client=mlflow.tracking.MlflowClient(tracking_uri='http://127.0.0.1:$MLFLOW_PORT'); exp=client.get_experiment_by_name('$MLFLOW_EXPERIMENT_NAME'); client.restore_experiment(exp.experiment_id) if exp and exp.lifecycle_stage == 'deleted' else None\" && mlflow autolog claude -u http://127.0.0.1:$MLFLOW_PORT -n $MLFLOW_EXPERIMENT_NAME; fi"
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then python3 -c \"import mlflow; client=mlflow.tracking.MlflowClient(tracking_uri='$MLFLOW_TRACKING_URI'); exp=client.get_experiment_by_name('$MLFLOW_EXPERIMENT_NAME'); client.restore_experiment(exp.experiment_id) if exp and exp.lifecycle_stage == 'deleted' else None\" && mlflow autolog claude -u $MLFLOW_TRACKING_URI -n $MLFLOW_EXPERIMENT_NAME; fi"
           }
         ]
       }
@@ -46,16 +44,6 @@
           {
             "type": "command",
             "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
-          }
-        ]
-      }
-    ],
-    "SessionEnd": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "pkill -f \"ssh.*-L.*$MLFLOW_PORT.*localhost:5000.*$JUMPBOX_URI\" 2>/dev/null || true"
           }
         ]
       }

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -33,7 +33,7 @@
           },
           {
             "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then python3 -c \"import mlflow; client=mlflow.tracking.MlflowClient(tracking_uri='$MLFLOW_TRACKING_URI'); exp=client.get_experiment_by_name('$MLFLOW_EXPERIMENT_NAME'); client.restore_experiment(exp.experiment_id) if exp and exp.lifecycle_stage == 'deleted' else None\" && mlflow autolog claude -u $MLFLOW_TRACKING_URI -n $MLFLOW_EXPERIMENT_NAME; fi"
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude; fi"
           }
         ]
       }

--- a/docs/mlflow-tracing.md
+++ b/docs/mlflow-tracing.md
@@ -23,7 +23,7 @@ Use `.claude/settings.example.json` and copy the MLflow-related keys/hook blocks
 - Global: `~/.claude/settings.json`
 
 Required pieces:
-- `MLFLOW_CLAUDE_TRACING_ENABLED`, `MLFLOW_PORT`, `MLFLOW_EXPERIMENT_NAME`
+- `MLFLOW_CLAUDE_TRACING_ENABLED`, `MLFLOW_TRACKING_URI`, `MLFLOW_EXPERIMENT_NAME`
 - `SessionStart` and `Stop` hooks
 Note: Set MLFLOW_CLAUDE_TRACING_ENABLED to false to disable tracking
 ## 4) Start claude

--- a/skills/root-cause-analysis/README.md
+++ b/skills/root-cause-analysis/README.md
@@ -176,7 +176,7 @@ MLflow tracing is supported for debugging and performance analysis but is **not 
 
 To enable tracing:
 1. Install MLflow: `pip install "mlflow[genai]>=3.4"` (or `pip install -e ".[mlflow]"` from the repo root)
-2. Configure `MLFLOW_PORT`, `MLFLOW_EXPERIMENT_NAME`, and optionally `JUMPBOX_URI` in `.claude/settings.json`
+2. Configure `MLFLOW_TRACKING_URI` and `MLFLOW_EXPERIMENT_NAME` in `.claude/settings.json`
 3. Add the required MLflow hooks to `.claude/settings.json`:
    ```json
    "hooks": {

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -35,7 +35,7 @@ Review the JSON output. Some settings are required, others are optional:
 - **JUMPBOX_URI** -- SSH jumpbox connection for uploading analysis results and feedback
 
 **Recommended** (analysis works without these but functionality is reduced):
-- **MLFlow** -- Tracing configuration for recording analysis runs (MLFLOW_PORT, MLFLOW_EXPERIMENT_NAME, MLFLOW_TAG_USER)
+- **MLFlow** -- Tracing configuration for recording analysis runs (MLFLOW_TRACKING_URI, MLFLOW_EXPERIMENT_NAME, MLFLOW_TAG_USER)
 
 **Optional** (skill runs with reduced functionality when missing):
 - **SSH / REMOTE_HOST** not configured: `--fetch` flag won't work (user must provide logs in JOB_LOGS_DIR manually)
@@ -61,7 +61,7 @@ If any checks have `"status": "missing"` and `"configurable": true`, offer to he
      - Then set `REMOTE_HOST` to the alias name
 4. After collecting all values, read the project's `.claude/settings.json` file
 5. Merge the new values into the `"env"` block (create it if it doesn't exist)
-6. If MLflow env vars were configured (MLFLOW_PORT, MLFLOW_EXPERIMENT_NAME), also add the required MLflow hooks to the `"hooks"` block (create it if it doesn't exist):
+6. If MLflow env vars were configured (MLFLOW_TRACKING_URI, MLFLOW_EXPERIMENT_NAME), also add the required MLflow hooks to the `"hooks"` block (create it if it doesn't exist):
    ```json
    "hooks": {
      "SessionStart": [
@@ -73,20 +73,29 @@ If any checks have `"status": "missing"` and `"configurable": true`, offer to he
           },
           {
             "type": "command",
-            "command": "if ! lsof -iTCP:$MLFLOW_PORT -sTCP:LISTEN >/dev/null 2>&1; then ssh -f -N -o ExitOnForwardFailure=yes -L $MLFLOW_PORT:localhost:5000 $JUMPBOX_URI; fi"
-          },
-          {
-            "type": "command",
             "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
           },
           {
             "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then python3 -c \"import mlflow; client=mlflow.tracking.MlflowClient(tracking_uri='http://127.0.0.1:$MLFLOW_PORT'); exp=client.get_experiment_by_name('$MLFLOW_EXPERIMENT_NAME'); client.restore_experiment(exp.experiment_id) if exp and exp.lifecycle_stage == 'deleted' else None\" && mlflow autolog claude -u http://127.0.0.1:$MLFLOW_PORT -n $MLFLOW_EXPERIMENT_NAME; fi"
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then  mlflow autolog claude -u $MLFLOW_TRACKING_URI -n $MLFLOW_EXPERIMENT_NAME; fi"
           }
         ]
       }
     ],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\"" }] }],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
+          },
+          {
+            "type": "command",
+            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude --disable; fi"
+          }
+        ]
+      }
+    ]
    }
    ```
 7. Write the updated settings file

--- a/skills/root-cause-analysis/scripts/setup.py
+++ b/skills/root-cause-analysis/scripts/setup.py
@@ -299,13 +299,10 @@ def check_github_mcp(repo_root: Path) -> dict:
 
 
 def _get_tracking_uri() -> str | None:
-    """Get MLflow tracking URI from env, deriving from MLFLOW_PORT if needed."""
+    """Get MLflow tracking URI from env. MLFLOW_TRACKING_URI is required."""
     uri = os.environ.get("MLFLOW_TRACKING_URI", "")
     if uri and not is_placeholder(uri):
         return uri
-    port = os.environ.get("MLFLOW_PORT", "")
-    if port and not is_placeholder(port):
-        return f"http://127.0.0.1:{port}"
     return None
 
 
@@ -395,9 +392,33 @@ def _parse_uri_port(tracking_uri: str) -> str | None:
         from urllib.parse import urlparse
 
         parsed = urlparse(tracking_uri)
-        return str(parsed.port) if parsed.port else None
+        if parsed.port:
+            return str(parsed.port)
+        # Return default ports for common schemes
+        if parsed.scheme == "https":
+            return "443"
+        elif parsed.scheme == "http":
+            return "80"
+        return None
     except Exception:
         return None
+
+
+def _parse_uri_host(tracking_uri: str) -> str | None:
+    """Extract hostname from a tracking URI."""
+    try:
+        from urllib.parse import urlparse
+
+        parsed = urlparse(tracking_uri)
+        return parsed.hostname
+    except Exception:
+        return None
+
+
+def _is_local_uri(tracking_uri: str) -> bool:
+    """Check if tracking URI points to localhost."""
+    host = _parse_uri_host(tracking_uri)
+    return host in ("localhost", "127.0.0.1", "::1") if host else False
 
 
 def _tunnel_already_running(port: str) -> bool:
@@ -415,16 +436,38 @@ def _tunnel_already_running(port: str) -> bool:
 
 
 def _start_ssh_tunnel(tracking_uri: str, jumpbox_uri: str) -> dict:
-    """Attempt to start an SSH tunnel to the MLFlow server."""
-    port = _parse_uri_port(tracking_uri)
-    if not port:
-        return {"started": False, "message": f"Could not parse port from {tracking_uri}"}
+    """Attempt to start an SSH tunnel to the MLFlow server.
 
-    if _tunnel_already_running(port):
-        return {"started": False, "message": f"Tunnel already running on port {port}"}
+    For remote MLflow servers, creates tunnel: local_port -> remote_host:remote_port
+    For local URIs, uses the configured MLFLOW_PORT if available.
+    """
+    remote_host = _parse_uri_host(tracking_uri)
+    remote_port = _parse_uri_port(tracking_uri)
+
+    if not remote_host or not remote_port:
+        return {"started": False, "message": f"Could not parse host/port from {tracking_uri}"}
+
+    # Determine local port: use MLFLOW_PORT if set, otherwise use remote port
+    local_port = os.environ.get("MLFLOW_PORT", "")
+    if is_placeholder(local_port):
+        local_port = remote_port
+
+    if _tunnel_already_running(local_port):
+        return {"started": False, "message": f"Tunnel already running on port {local_port}"}
 
     try:
-        cmd = ["ssh", "-f", "-N", "-L", f"{port}:127.0.0.1:{port}"] + jumpbox_uri.split()
+        # Format: ssh -L local_port:remote_host:remote_port jumpbox
+        forward_spec = f"{local_port}:{remote_host}:{remote_port}"
+        cmd = [
+            "ssh",
+            "-f",
+            "-N",
+            "-o",
+            "ExitOnForwardFailure=yes",
+            "-L",
+            forward_spec,
+        ] + jumpbox_uri.split()
+
         result = subprocess.run(
             cmd,
             capture_output=True,
@@ -433,7 +476,11 @@ def _start_ssh_tunnel(tracking_uri: str, jumpbox_uri: str) -> dict:
         )
         if result.returncode != 0:
             return {"started": False, "message": f"SSH tunnel failed: {result.stderr.strip()}"}
-        return {"started": True, "message": f"Tunnel started on port {port} via {jumpbox_uri}"}
+
+        return {
+            "started": True,
+            "message": f"Tunnel started: localhost:{local_port} -> {remote_host}:{remote_port} via {jumpbox_uri}",
+        }
     except subprocess.TimeoutExpired:
         return {"started": False, "message": "SSH tunnel timed out"}
     except Exception as e:
@@ -462,43 +509,20 @@ def check_mlflow_server() -> dict:
     if not tracking_uri:
         return {
             "name": "MLFlow server",
-            "status": "missing",
-            "message": "MLFLOW_PORT not configured",
+            "status": "error",
+            "message": "MLFLOW_TRACKING_URI not configured",
         }
 
-    # First check: is it already reachable?
+    # Check if server is reachable
     reachable = _is_server_reachable(tracking_uri)
 
     if not reachable:
-        # Not reachable -- try to start SSH tunnel if JUMPBOX_URI is configured
-        jumpbox = os.environ.get("JUMPBOX_URI", "")
-        if is_placeholder(jumpbox):
-            return {
-                "name": "MLFlow server",
-                "status": "error",
-                "message": f"Cannot reach {tracking_uri}. Set JUMPBOX_URI for SSH tunnel",
-            }
-
-        # Kill any stale tunnel before starting a fresh one
-        port = _parse_uri_port(tracking_uri)
-        if port and _tunnel_already_running(port):
-            _kill_stale_tunnel(port)
-
-        # Attempt tunnel startup
-        tunnel_result = _start_ssh_tunnel(tracking_uri, jumpbox)
-
-        if tunnel_result["started"]:
-            import time
-
-            time.sleep(2)
-            reachable = _is_server_reachable(tracking_uri)
-
-        if not reachable:
-            return {
-                "name": "MLFlow server",
-                "status": "error",
-                "message": f"Cannot reach {tracking_uri}. Tunnel: {tunnel_result['message']}",
-            }
+        # Not reachable - cannot proceed
+        return {
+            "name": "MLFlow server",
+            "status": "error",
+            "message": f"Cannot reach {tracking_uri}",
+        }
 
     return {
         "name": "MLFlow server",


### PR DESCRIPTION
for getting mlflow traces on remote

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configuration now supports connecting to external MLflow tracking servers via a tracking URI and optional username/password credentials.
  * Default autolog/tracking uses the configured tracking URI instead of relying on a local port-forwarded MLflow endpoint; SSH tunnel setup/cleanup is no longer used.
  * Example experiment name updated to "rhdp-rca-plugin-traces".
* **Documentation**
  * Updated setup and tracing docs to reflect the new tracking URI configuration and simplified tracing commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->