### PR TITLE
Fix/mlflow setup checks

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -30,10 +30,6 @@
           {
             "type": "command",
             "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
-          },
-          {
-            "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude; fi"
           }
         ]
       }

--- a/skills/root-cause-analysis/SKILL.md
+++ b/skills/root-cause-analysis/SKILL.md
@@ -74,10 +74,6 @@ If any checks have `"status": "missing"` and `"configurable": true`, offer to he
           {
             "type": "command",
             "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then if ! pip show mlflow >/dev/null 2>&1; then pip install mlflow; fi; fi"
-          },
-          {
-            "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then  mlflow autolog claude -u $MLFLOW_TRACKING_URI -n $MLFLOW_EXPERIMENT_NAME; fi"
           }
         ]
       }
@@ -88,10 +84,6 @@ If any checks have `"status": "missing"` and `"configurable": true`, offer to he
           {
             "type": "command",
             "command": "python -c \"from mlflow.claude_code.hooks import stop_hook_handler; stop_hook_handler()\""
-          },
-          {
-            "type": "command",
-            "command": "if [ \"$MLFLOW_CLAUDE_TRACING_ENABLED\" = \"true\" ]; then mlflow autolog claude --disable; fi"
           }
         ]
       }

--- a/skills/root-cause-analysis/scripts/setup.py
+++ b/skills/root-cause-analysis/scripts/setup.py
@@ -308,26 +308,47 @@ def _get_tracking_uri() -> str | None:
 
 def check_mlflow() -> dict:
     """Check MLFlow tracing configuration."""
-    enabled = os.environ.get("MLFLOW_CLAUDE_TRACING_ENABLED", "")
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "")
+    username = os.environ.get("MLFLOW_TRACKING_USERNAME", "")
+    password = os.environ.get("MLFLOW_TRACKING_PASSWORD", "")
     experiment = os.environ.get("MLFLOW_EXPERIMENT_NAME", "")
     tag_user = os.environ.get("MLFLOW_TAG_USER", "")
 
     env_vars = []
     issues = []
 
-    if enabled.lower() != "true":
-        issues.append("MLFLOW_CLAUDE_TRACING_ENABLED not set to 'true'")
+    if is_placeholder(tracking_uri):
+        issues.append("MLFLOW_TRACKING_URI not configured")
         env_vars.append(
             {
-                "name": "MLFLOW_CLAUDE_TRACING_ENABLED",
-                "prompt": "Enable MLFlow tracing (true/false)",
-                "default": "true",
+                "name": "MLFLOW_TRACKING_URI",
+                "prompt": "MLflow tracking URI (e.g. https://mlflow.example.com)",
+            }
+        )
+    if is_placeholder(username):
+        issues.append("MLFLOW_TRACKING_USERNAME not configured")
+        env_vars.append(
+            {
+                "name": "MLFLOW_TRACKING_USERNAME",
+                "prompt": "MLflow tracking username",
+            }
+        )
+    if is_placeholder(password):
+        issues.append("MLFLOW_TRACKING_PASSWORD not configured")
+        env_vars.append(
+            {
+                "name": "MLFLOW_TRACKING_PASSWORD",
+                "prompt": "MLflow tracking password",
             }
         )
     if is_placeholder(experiment):
         issues.append("MLFLOW_EXPERIMENT_NAME not configured")
         env_vars.append(
-            {"name": "MLFLOW_EXPERIMENT_NAME", "prompt": "MLFlow experiment name for tracing"}
+            {
+                "name": "MLFLOW_EXPERIMENT_NAME",
+                "prompt": "MLFlow experiment name for tracing",
+                "optional": True,
+            }
         )
     if is_placeholder(tag_user):
         issues.append("MLFLOW_TAG_USER not configured")
@@ -351,7 +372,7 @@ def check_mlflow() -> dict:
     return {
         "name": "MLFlow",
         "status": "ok",
-        "message": f"experiment={experiment}",
+        "message": f"uri={tracking_uri}, experiment={experiment}",
     }
 
 
@@ -530,47 +551,35 @@ def check_mlflow_server() -> dict:
 
 
 def check_mlflow_hooks(repo_root: Path) -> dict:
-    """Check if MLflow Stop and SessionStart hooks are configured in settings.json."""
-    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "")
-    if tracking_uri and not is_placeholder(tracking_uri):
-        return {
-            "name": "MLflow hooks",
-            "status": "ok",
-            "message": "mlflow autolog configured via MLFLOW_TRACKING_URI",
-        }
+    """Check if MLflow Stop hook is configured in settings.json."""
+    import subprocess
 
-    for settings_name in ["settings.json", "settings.local.json"]:
-        settings_path = repo_root / ".claude" / settings_name
-        if settings_path.exists():
-            try:
-                with open(settings_path) as f:
-                    settings = json.load(f)
-                hooks = settings.get("hooks", {})
-                has_stop = "Stop" in hooks
-                has_session = "SessionStart" in hooks
-                if has_stop and has_session:
-                    return {
-                        "name": "MLflow hooks",
-                        "status": "ok",
-                        "message": f"Stop + SessionStart registered in {settings_name}",
-                    }
-                missing = []
-                if not has_stop:
-                    missing.append("Stop")
-                if not has_session:
-                    missing.append("SessionStart")
-                return {
-                    "name": "MLflow hooks",
-                    "status": "missing",
-                    "message": f"Missing hooks: {', '.join(missing)}. See settings.example.json",
-                }
-            except (json.JSONDecodeError, OSError):
-                pass
+    search_roots = [repo_root]
+    cwd = Path.cwd()
+    if cwd != repo_root:
+        search_roots.insert(0, cwd)
+
+    for root in search_roots:
+        for settings_name in ["settings.json", "settings.local.json"]:
+            settings_path = root / ".claude" / settings_name
+            if settings_path.exists():
+                try:
+                    with open(settings_path) as f:
+                        settings = json.load(f)
+                    hooks = settings.get("hooks", {})
+                    if "Stop" in hooks:
+                        return {
+                            "name": "MLflow hooks",
+                            "status": "ok",
+                            "message": f"Stop hook registered in {settings_name}",
+                        }
+                except (json.JSONDecodeError, OSError):
+                    pass
 
     return {
         "name": "MLflow hooks",
         "status": "missing",
-        "message": "Stop and SessionStart hooks not found in settings. See settings.example.json",
+        "message": "Missing Stop hook. See settings.example.json",
     }
 
 

--- a/skills/root-cause-analysis/scripts/setup.py
+++ b/skills/root-cause-analysis/scripts/setup.py
@@ -552,8 +552,6 @@ def check_mlflow_server() -> dict:
 
 def check_mlflow_hooks(repo_root: Path) -> dict:
     """Check if MLflow Stop hook is configured in settings.json."""
-    import subprocess
-
     search_roots = [repo_root]
     cwd = Path.cwd()
     if cwd != repo_root:

--- a/skills/root-cause-analysis/scripts/setup.py
+++ b/skills/root-cause-analysis/scripts/setup.py
@@ -308,7 +308,6 @@ def _get_tracking_uri() -> str | None:
 
 def check_mlflow() -> dict:
     """Check MLFlow tracing configuration."""
-    port = os.environ.get("MLFLOW_PORT", "")
     enabled = os.environ.get("MLFLOW_CLAUDE_TRACING_ENABLED", "")
     experiment = os.environ.get("MLFLOW_EXPERIMENT_NAME", "")
     tag_user = os.environ.get("MLFLOW_TAG_USER", "")
@@ -316,14 +315,6 @@ def check_mlflow() -> dict:
     env_vars = []
     issues = []
 
-    if is_placeholder(port):
-        issues.append("MLFLOW_PORT not configured")
-        env_vars.append(
-            {
-                "name": "MLFLOW_PORT",
-                "prompt": "Localhost port for MLflow server (e.g. 5000)",
-            }
-        )
     if enabled.lower() != "true":
         issues.append("MLFLOW_CLAUDE_TRACING_ENABLED not set to 'true'")
         env_vars.append(
@@ -360,19 +351,26 @@ def check_mlflow() -> dict:
     return {
         "name": "MLFlow",
         "status": "ok",
-        "message": f"port={port}, experiment={experiment}",
+        "message": f"experiment={experiment}",
     }
 
 
 def _is_server_reachable(tracking_uri: str) -> bool:
     """Check if MLFlow server is reachable by verifying the response is actually MLFlow."""
     try:
+        import base64
         import urllib.error
         import urllib.request
 
         req = urllib.request.Request(
             f"{tracking_uri}/api/2.0/mlflow/experiments/search", method="GET"
         )
+        username = os.environ.get("MLFLOW_TRACKING_USERNAME", "")
+        password = os.environ.get("MLFLOW_TRACKING_PASSWORD", "")
+        if username and password:
+            credentials = base64.b64encode(f"{username}:{password}".encode()).decode()
+            req.add_header("Authorization", f"Basic {credentials}")
+
         resp = urllib.request.urlopen(req, timeout=5)
         body = resp.read().decode("utf-8", errors="replace")
         return "mlflow" in body.lower() or "experiments" in body.lower()
@@ -533,6 +531,14 @@ def check_mlflow_server() -> dict:
 
 def check_mlflow_hooks(repo_root: Path) -> dict:
     """Check if MLflow Stop and SessionStart hooks are configured in settings.json."""
+    tracking_uri = os.environ.get("MLFLOW_TRACKING_URI", "")
+    if tracking_uri and not is_placeholder(tracking_uri):
+        return {
+            "name": "MLflow hooks",
+            "status": "ok",
+            "message": "mlflow autolog configured via MLFLOW_TRACKING_URI",
+        }
+
     for settings_name in ["settings.json", "settings.local.json"]:
         settings_path = repo_root / ".claude" / settings_name
         if settings_path.exists():


### PR DESCRIPTION
Builds on top of and fixes https://github.com/redhat-et/rhdp-rca-plugin/pull/31 

- Remove MLFLOW_PORT check from check_mlflow() since we use MLFLOW_TRACKING_URI directly
- Remove mlflow autolog claude from SessionStart hooks (it's a one-time setup command, not a per-session hook)
- Add Basic auth credentials to _is_server_reachable() so authenticated MLflow servers are detected correctly
- check_mlflow(): Check MLFLOW_TRACKING_URI + auth credentials instead of
  MLFLOW_CLAUDE_TRACING_ENABLED; EXPERIMENT_NAME and TAG_USER are optional
- check_mlflow_hooks(): Only require Stop hook; search project cwd in
  addition to repo_root so hooks are found when running from plugin cache
- Remove unused subprocess import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * MLflow endpoint connectivity validation now supports credential-based authentication.

* **Chores**
  * Updated MLflow configuration setup to use tracking URI and credentials.
  * Streamlined MLflow tracing hooks configuration in example setup files.
  * Made MLflow experiment name optional in configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->