### PR TITLE
Add cross-SDK benchmark harness for root-cause-analysis skill

### DIFF
--- a/experiments/sdk_benchmark/.gitignore
+++ b/experiments/sdk_benchmark/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+node_modules/
+__pycache__/
+*.pyc
+results/*.json
+results/*.md
+!results/.gitkeep
+package-lock.json

--- a/experiments/sdk_benchmark/.gitignore
+++ b/experiments/sdk_benchmark/.gitignore
@@ -5,4 +5,3 @@ __pycache__/
 results/*.json
 results/*.md
 !results/.gitkeep
-package-lock.json

--- a/experiments/sdk_benchmark/README.md
+++ b/experiments/sdk_benchmark/README.md
@@ -1,0 +1,182 @@
+# SDK benchmark — root-cause-analysis
+
+A runnable, apples-to-apples benchmark that drives the `skills/root-cause-analysis`
+skill from three SDKs and measures success rate, cost, and wall time:
+
+- **Claude Agent SDK** (Python, native — loads SKILL.md content as a system-prompt addendum)
+- **OpenCode SDK** (TypeScript, via a Node runner the Python harness shells out to)
+- **Pi Coding Agent SDK** (TypeScript, via a Node runner the Python harness shells out to)
+
+All three are pointed at the same Claude model, fed the same SKILL.md body as a
+system prompt, given the same tool set, and scored against the same scenarios.
+
+## Why this design
+
+Each SDK has its own "skills" loading semantics (`.claude/skills/`, `.opencode/agents/`,
+`.pi/skills/`) with different metadata. To compare orchestration quality rather
+than skill-loader quirks, the harness reads `SKILL.md` once, strips the YAML
+frontmatter, and injects the body as the system prompt for every adapter. The
+agent then has identical instructions in every run.
+
+## Layout
+
+```
+sdk_benchmark/
+├── benchmark/
+│   ├── cli.py                  # python -m benchmark.cli run …
+│   ├── pricing.py              # USD/Mtok lookup for cost fallback
+│   ├── scenarios.py            # YAML loader + dataclass
+│   ├── scenarios.yaml          # Edit me — define real RCA scenarios
+│   ├── scoring.py              # Keyword + tool-call + budget scoring
+│   ├── report.py               # Markdown + JSON report writer
+│   ├── skill_loader.py         # Strip YAML frontmatter from SKILL.md
+│   ├── adapters/
+│   │   ├── base.py             # Adapter ABC, SkillRunRequest, SkillRunResult
+│   │   ├── claude_agent.py
+│   │   ├── opencode.py
+│   │   ├── pi.py
+│   │   └── _subprocess.py      # Shared Node-runner driver
+│   └── runners/
+│       ├── opencode_runner.mjs # OpenCode SDK call
+│       └── pi_runner.mjs       # Pi SDK call
+├── requirements.txt
+├── package.json
+└── results/                    # Output reports (gitignore if you wish)
+```
+
+## Setup
+
+```bash
+cd experiments/sdk_benchmark
+
+# Python deps (in a venv of your choice)
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+
+# Node deps (only needed for OpenCode + Pi adapters)
+npm install
+```
+
+### Required env vars
+
+Pick a provider:
+
+**Option A — Anthropic direct:**
+```bash
+export ANTHROPIC_API_KEY=sk-ant-…
+# Run with --provider anthropic --model claude-sonnet-4-6
+```
+
+**Option B — OpenRouter** (works for all three SDKs):
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-…
+# Run with --provider openrouter --model anthropic/claude-sonnet-4.6
+```
+
+OpenRouter notes:
+- The harness sets `ANTHROPIC_BASE_URL=https://openrouter.ai/api`, `ANTHROPIC_AUTH_TOKEN=$OPENROUTER_API_KEY`, and blanks `ANTHROPIC_API_KEY` for the Claude Agent SDK. **It overwrites any pre-set `ANTHROPIC_*` env vars** — this matters when running the harness inside another Claude Code session, which leaks routing vars to subprocesses.
+- OpenCode picks up `OPENROUTER_API_KEY` directly and uses the `openrouter/anthropic/claude-sonnet-4.6` model slug.
+- Pi reads `OPENROUTER_API_KEY` via `AuthStorage.setRuntimeApiKey("openrouter", …)`.
+
+Only needed for scenarios that actually run an RCA against real infra:
+```bash
+export JUMPBOX_URI="user@host -p 2222"
+export SPLUNK_URL=…
+export SPLUNK_TOKEN=…
+export GITHUB_TOKEN=…  # if the skill's scripts/github_fetcher.py uses it
+```
+
+The skill's Python scripts read these directly; the harness does not need them.
+
+## Quick smoke test
+
+Verify the harness loads cleanly without spending tokens:
+
+```bash
+.venv/bin/python -m benchmark.cli run \
+  --scenarios benchmark/scenarios.yaml \
+  --skill ../../skills/root-cause-analysis \
+  --dry-run
+```
+
+## Run the benchmark
+
+**Anthropic direct:**
+```bash
+.venv/bin/python -m benchmark.cli run \
+  --scenarios benchmark/scenarios.yaml \
+  --skill ../../skills/root-cause-analysis \
+  --provider anthropic \
+  --model claude-sonnet-4-6 \
+  --adapters claude-agent-sdk,opencode,pi
+```
+
+**OpenRouter:**
+```bash
+.venv/bin/python -m benchmark.cli run \
+  --scenarios benchmark/scenarios-light.yaml \
+  --skill ../../skills/root-cause-analysis \
+  --provider openrouter \
+  --model anthropic/claude-sonnet-4.6 \
+  --adapters claude-agent-sdk,opencode,pi
+```
+
+Reports land in `results/results-<timestamp>.{md,json}`.
+
+A lighter `scenarios-light.yaml` ships alongside `scenarios.yaml` — it exercises only reasoning + skill-loading (no SSH/Splunk/GitHub), so you can run a real comparison without RHDP infrastructure.
+
+To benchmark a single adapter (e.g. while iterating on scenarios):
+
+```bash
+.venv/bin/python -m benchmark.cli run ... --adapters claude-agent-sdk
+```
+
+## Authoring scenarios
+
+Edit `benchmark/scenarios.yaml`. Each scenario has:
+
+| field | meaning |
+|---|---|
+| `id` | Unique identifier (used in reports). |
+| `description` | Human-readable note. |
+| `prompt` | What the user would type. |
+| `expected_keywords` | Case-insensitive substrings that must appear in the final agent output. |
+| `expected_tool_calls` | Tool names the agent **must** invoke at least once (e.g. `Bash`). |
+| `forbidden_tool_calls` | Tool names that must NOT be called. |
+| `max_cost_usd` | Cost cap — scenarios over budget count as failures. |
+| `timeout_seconds` | Hard wall-clock cap. |
+
+Three starter scenarios ship with the harness:
+1. `preflight-only` — runs without any RHDP infra, exercises the skill's setup checks.
+2. `missing-job-id` — checks the agent refuses to fabricate a job ID.
+3. `real-job-analysis` — full RCA. **You must fill in a real job ID and tune the expected keywords** before this scenario produces useful signal.
+
+## Scoring
+
+A run **succeeds** iff all four hold:
+1. The SDK call returned without raising.
+2. Every `expected_keyword` appears in the final output (case-insensitive).
+3. Every `expected_tool_call` was invoked at least once, and no `forbidden_tool_calls` were.
+4. Total cost did not exceed `max_cost_usd`.
+
+`success_rate = successes / total_runs` per adapter.
+
+## Cost accounting
+
+- **Claude Agent SDK** reports `total_cost_usd` directly on `ResultMessage`. The harness uses that.
+- **OpenCode** and **Pi** expose token counts. The harness either reads any native cost field they surface or falls back to multiplying tokens by `benchmark/pricing.py`. Update that table when Anthropic publishes new rates.
+- All three are pinned to the same model, so cost differences reflect prompt size, agent loop length, and retry behavior — not model price.
+
+## Limitations & honest caveats
+
+- **MCP servers**: The Claude-flavored `mcp__github__*` / `mcp__atlassian__*` / `mcp__slack__*` tools listed in `SKILL.md` are not used here. The agent only gets the universal tools (`Read`, `Write`, `Edit`, `Bash`, `Grep`, `Glob`). The skill's own Python scripts handle GitHub/Splunk access via env vars. If you want MCP parity across SDKs, extend each adapter with the SDK's MCP config.
+- **Permissions**: All adapters run with auto-approval (`bypassPermissions` on Claude Agent SDK; equivalent flags on the others). This is benchmark code, not interactive use.
+- **Same model required**: The default scenarios are tuned for Claude. If you switch one adapter to GPT or another provider, the keyword scoring may need updating — but the cost numbers won't be directly comparable.
+- **OpenCode + Pi APIs are young**: The Node runners use best-effort field probing (`u.input ?? u.inputTokens ?? 0`) because both SDKs are evolving. If a field name changed upstream, the `usage` numbers may read 0 — the harness will then fall back to `pricing.py` (which needs token counts to compute cost, so the cost will also be 0). Update the runners if you see this.
+- **No real RCA without creds**: `real-job-analysis` needs the same SSH + Splunk + GitHub setup that the skill itself needs. The `preflight-only` and `missing-job-id` scenarios work without any of that.
+
+## Extending
+
+- **Add a fourth SDK**: subclass `Adapter` in `benchmark/adapters/`, register it in `ADAPTERS` in `cli.py`.
+- **Add MCP servers**: Pass `mcp_servers` through `ClaudeAgentOptions` in `claude_agent.py`; mirror in the two `.mjs` runners.
+- **Different models per adapter**: extend `SkillRunRequest` with per-adapter overrides and surface a `--per-adapter-model` flag.

--- a/experiments/sdk_benchmark/benchmark/__init__.py
+++ b/experiments/sdk_benchmark/benchmark/__init__.py
@@ -1,0 +1,3 @@
+"""SDK benchmark harness for the root-cause-analysis skill."""
+
+__version__ = "0.1.0"

--- a/experiments/sdk_benchmark/benchmark/adapters/__init__.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/__init__.py
@@ -1,0 +1,3 @@
+from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
+
+__all__ = ["Adapter", "SkillRunRequest", "SkillRunResult", "TokenUsage"]

--- a/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
@@ -1,0 +1,115 @@
+"""Shared logic for adapters that delegate to a Node.js runner subprocess.
+
+The contract:
+- We spawn `node <runner>` with the request as JSON on stdin.
+- The runner emits a single JSON object on stdout with the result.
+- Stderr is captured and surfaced if the runner exits non-zero.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+from pathlib import Path
+
+from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
+from ..skill_loader import skill_body
+
+
+def run_node_adapter(
+    name: str,
+    runner_path: Path,
+    request: SkillRunRequest,
+) -> SkillRunResult:
+    body = skill_body(request.skill_path)
+    payload = {
+        "prompt": request.prompt,
+        "systemPrompt": body,
+        "model": request.model,
+        "cwd": str(request.cwd or request.skill_path.parent),
+        "allowedTools": request.allowed_tools,
+        "timeoutSeconds": request.timeout_seconds,
+        "provider": request.provider,
+    }
+
+    started = time.monotonic()
+    # Prepend our local node_modules/.bin to PATH so the SDK can spawn the
+    # bundled `opencode` binary without a global install.
+    benchmark_root = Path(__file__).resolve().parents[2]
+    local_bin = benchmark_root / "node_modules" / ".bin"
+    env = _runner_env(request)
+    env["PATH"] = f"{local_bin}{':' if env.get('PATH') else ''}{env.get('PATH', '')}"
+    try:
+        proc = subprocess.run(
+            ["node", str(runner_path)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=request.timeout_seconds + 30,
+        )
+    except FileNotFoundError:
+        return _error(name, request, "node executable not found. Install Node 18+ and ensure `node` is on PATH.")
+    except subprocess.TimeoutExpired:
+        return _error(name, request, f"runner exceeded timeout ({request.timeout_seconds}s)")
+
+    duration = time.monotonic() - started
+
+    if proc.returncode != 0:
+        return _error(
+            name,
+            request,
+            f"runner exited {proc.returncode}: {proc.stderr.strip()[:2000]}",
+            duration=duration,
+        )
+
+    try:
+        data = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        return _error(
+            name,
+            request,
+            f"could not parse runner output. stdout={proc.stdout[:500]!r} stderr={proc.stderr[:500]!r}",
+            duration=duration,
+        )
+
+    usage_raw = data.get("usage") or {}
+    return SkillRunResult(
+        adapter=name,
+        scenario_id=request.scenario_id,
+        model=request.model,
+        success=data.get("error") is None,
+        final_text=data.get("finalText", ""),
+        tool_calls=data.get("toolCalls", []),
+        usage=TokenUsage(
+            input_tokens=usage_raw.get("input", 0),
+            output_tokens=usage_raw.get("output", 0),
+            cache_read_tokens=usage_raw.get("cacheRead", 0),
+            cache_write_tokens=usage_raw.get("cacheWrite", 0),
+        ),
+        native_cost_usd=data.get("nativeCostUsd"),
+        duration_seconds=data.get("durationSeconds", duration),
+        num_turns=data.get("numTurns", 0),
+        error=data.get("error"),
+        raw=data.get("raw") or {},
+    )
+
+
+def _runner_env(request: SkillRunRequest) -> dict[str, str]:
+    import os
+    env = os.environ.copy()
+    env.update(request.env)
+    return env
+
+
+def _error(name: str, request: SkillRunRequest, msg: str, duration: float = 0.0) -> SkillRunResult:
+    return SkillRunResult(
+        adapter=name,
+        scenario_id=request.scenario_id,
+        model=request.model,
+        success=False,
+        final_text="",
+        duration_seconds=duration,
+        error=msg,
+    )

--- a/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
@@ -13,8 +13,8 @@ import subprocess
 import time
 from pathlib import Path
 
-from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
 from ..skill_loader import skill_body
+from .base import SkillRunRequest, SkillRunResult, TokenUsage
 
 
 def run_node_adapter(

--- a/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/_subprocess.py
@@ -50,7 +50,11 @@ def run_node_adapter(
             timeout=request.timeout_seconds + 30,
         )
     except FileNotFoundError:
-        return _error(name, request, "node executable not found. Install Node 18+ and ensure `node` is on PATH.")
+        return _error(
+            name,
+            request,
+            "node executable not found. Install Node 18+ and ensure `node` is on PATH.",
+        )
     except subprocess.TimeoutExpired:
         return _error(name, request, f"runner exceeded timeout ({request.timeout_seconds}s)")
 
@@ -98,6 +102,7 @@ def run_node_adapter(
 
 def _runner_env(request: SkillRunRequest) -> dict[str, str]:
     import os
+
     env = os.environ.copy()
     env.update(request.env)
     return env

--- a/experiments/sdk_benchmark/benchmark/adapters/base.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/base.py
@@ -24,7 +24,9 @@ class SkillRunRequest:
     """SDK-agnostic model name, e.g. 'claude-sonnet-4-6'. Adapters translate
     to the SDK's expected format."""
 
-    allowed_tools: list[str] = field(default_factory=lambda: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"])
+    allowed_tools: list[str] = field(
+        default_factory=lambda: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"]
+    )
     cwd: Path | None = None
     timeout_seconds: int = 600
     env: dict[str, str] = field(default_factory=dict)

--- a/experiments/sdk_benchmark/benchmark/adapters/base.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/base.py
@@ -1,0 +1,73 @@
+"""Adapter interface common to all three SDKs.
+
+Each adapter receives the same SkillRunRequest and returns the same
+SkillRunResult so the harness can score them uniformly.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class SkillRunRequest:
+    scenario_id: str
+    prompt: str
+    skill_path: Path
+    """Path to the skill directory (containing SKILL.md). The body of SKILL.md
+    will be injected as the system prompt; scripts under the directory are
+    available to the agent via Bash."""
+
+    model: str
+    """SDK-agnostic model name, e.g. 'claude-sonnet-4-6'. Adapters translate
+    to the SDK's expected format."""
+
+    allowed_tools: list[str] = field(default_factory=lambda: ["Read", "Write", "Edit", "Bash", "Grep", "Glob"])
+    cwd: Path | None = None
+    timeout_seconds: int = 600
+    env: dict[str, str] = field(default_factory=dict)
+    provider: str = "anthropic"
+    """One of: 'anthropic', 'openrouter'. Adapters use this to route auth."""
+
+
+@dataclass
+class TokenUsage:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+@dataclass
+class SkillRunResult:
+    adapter: str
+    scenario_id: str
+    model: str
+    success: bool
+    """True iff the SDK call completed without raising; scoring is separate."""
+
+    final_text: str
+    """Final assistant message text. Used for keyword scoring."""
+
+    tool_calls: list[str] = field(default_factory=list)
+    """Names of tools the agent invoked, in order."""
+
+    usage: TokenUsage = field(default_factory=TokenUsage)
+    native_cost_usd: float | None = None
+    """Cost reported by the SDK itself, if any."""
+
+    duration_seconds: float = 0.0
+    num_turns: int = 0
+    error: str | None = None
+    raw: dict = field(default_factory=dict)
+    """Adapter-specific extras (kept opaque so the report can dump them)."""
+
+
+class Adapter(ABC):
+    name: str
+
+    @abstractmethod
+    def run(self, request: SkillRunRequest) -> SkillRunResult:
+        """Execute the request synchronously and return a result."""

--- a/experiments/sdk_benchmark/benchmark/adapters/claude_agent.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/claude_agent.py
@@ -1,0 +1,110 @@
+"""Adapter for the Claude Agent SDK (Python)."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
+from ..skill_loader import skill_body
+
+
+class ClaudeAgentAdapter(Adapter):
+    name = "claude-agent-sdk"
+
+    def run(self, request: SkillRunRequest) -> SkillRunResult:
+        # asyncio.wait_for around the SDK's query() trips its anyio-based
+        # subprocess cleanup and surfaces as "Claude Code returned an error
+        # result: success". Skip the outer timeout; the SDK enforces its own.
+        return asyncio.run(self._run(request))
+
+    async def _run(self, request: SkillRunRequest) -> SkillRunResult:
+        try:
+            from claude_agent_sdk import (
+                ClaudeAgentOptions,
+                ResultMessage,
+                AssistantMessage,
+                query,
+            )
+        except ImportError as e:
+            return _import_error(request, str(e), self.name)
+
+        body = skill_body(request.skill_path)
+        options = ClaudeAgentOptions(
+            model=request.model,
+            system_prompt={
+                "type": "preset",
+                "preset": "claude_code",
+                "append": body,
+            },
+            allowed_tools=request.allowed_tools,
+            cwd=str(request.cwd or request.skill_path.parent),
+            permission_mode="bypassPermissions",
+        )
+
+        started = time.monotonic()
+        tool_calls: list[str] = []
+        final_text_parts: list[str] = []
+        usage = TokenUsage()
+        cost: float | None = None
+        num_turns = 0
+        error: str | None = None
+        result_raw: dict = {}
+
+        try:
+            async for message in query(prompt=request.prompt, options=options):
+                if isinstance(message, AssistantMessage):
+                    for block in message.content:
+                        if hasattr(block, "text"):
+                            final_text_parts.append(block.text)
+                        if hasattr(block, "name") and getattr(block, "type", "") == "tool_use":
+                            tool_calls.append(block.name)
+                elif isinstance(message, ResultMessage):
+                    if message.usage:
+                        usage = TokenUsage(
+                            input_tokens=message.usage.get("input_tokens", 0),
+                            output_tokens=message.usage.get("output_tokens", 0),
+                            cache_read_tokens=message.usage.get("cache_read_input_tokens", 0),
+                            cache_write_tokens=message.usage.get("cache_creation_input_tokens", 0),
+                        )
+                    cost = message.total_cost_usd
+                    num_turns = message.num_turns
+                    if message.result:
+                        final_text_parts = [message.result]
+                    result_raw = {
+                        "subtype": message.subtype,
+                        "stop_reason": message.stop_reason,
+                        "duration_api_ms": message.duration_api_ms,
+                    }
+                    if message.is_error:
+                        error = "; ".join(message.errors or []) or message.subtype
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {exc}"
+
+        duration = time.monotonic() - started
+        return SkillRunResult(
+            adapter=self.name,
+            scenario_id=request.scenario_id,
+            model=request.model,
+            success=error is None,
+            final_text="\n".join(final_text_parts),
+            tool_calls=tool_calls,
+            usage=usage,
+            native_cost_usd=cost,
+            duration_seconds=duration,
+            num_turns=num_turns,
+            error=error,
+            raw=result_raw,
+        )
+
+
+def _import_error(request: SkillRunRequest, msg: str, name: str) -> SkillRunResult:
+    return SkillRunResult(
+        adapter=name,
+        scenario_id=request.scenario_id,
+        model=request.model,
+        success=False,
+        final_text="",
+        error=f"claude_agent_sdk not installed: {msg}. Install with `pip install claude-agent-sdk`.",
+    )

--- a/experiments/sdk_benchmark/benchmark/adapters/claude_agent.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/claude_agent.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import time
-from pathlib import Path
 
-from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
 from ..skill_loader import skill_body
+from .base import Adapter, SkillRunRequest, SkillRunResult, TokenUsage
 
 
 class ClaudeAgentAdapter(Adapter):
@@ -22,9 +21,9 @@ class ClaudeAgentAdapter(Adapter):
     async def _run(self, request: SkillRunRequest) -> SkillRunResult:
         try:
             from claude_agent_sdk import (
+                AssistantMessage,
                 ClaudeAgentOptions,
                 ResultMessage,
-                AssistantMessage,
                 query,
             )
         except ImportError as e:

--- a/experiments/sdk_benchmark/benchmark/adapters/opencode.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/opencode.py
@@ -1,0 +1,18 @@
+"""Adapter for the OpenCode SDK (delegates to a Node runner)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import Adapter, SkillRunRequest, SkillRunResult
+from ._subprocess import run_node_adapter
+
+
+RUNNER = Path(__file__).resolve().parents[1] / "runners" / "opencode_runner.mjs"
+
+
+class OpenCodeAdapter(Adapter):
+    name = "opencode"
+
+    def run(self, request: SkillRunRequest) -> SkillRunResult:
+        return run_node_adapter(self.name, RUNNER, request)

--- a/experiments/sdk_benchmark/benchmark/adapters/opencode.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/opencode.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .base import Adapter, SkillRunRequest, SkillRunResult
 from ._subprocess import run_node_adapter
-
+from .base import Adapter, SkillRunRequest, SkillRunResult
 
 RUNNER = Path(__file__).resolve().parents[1] / "runners" / "opencode_runner.mjs"
 

--- a/experiments/sdk_benchmark/benchmark/adapters/pi.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/pi.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .base import Adapter, SkillRunRequest, SkillRunResult
 from ._subprocess import run_node_adapter
-
+from .base import Adapter, SkillRunRequest, SkillRunResult
 
 RUNNER = Path(__file__).resolve().parents[1] / "runners" / "pi_runner.mjs"
 

--- a/experiments/sdk_benchmark/benchmark/adapters/pi.py
+++ b/experiments/sdk_benchmark/benchmark/adapters/pi.py
@@ -1,0 +1,18 @@
+"""Adapter for the Pi Coding Agent SDK (delegates to a Node runner)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .base import Adapter, SkillRunRequest, SkillRunResult
+from ._subprocess import run_node_adapter
+
+
+RUNNER = Path(__file__).resolve().parents[1] / "runners" / "pi_runner.mjs"
+
+
+class PiAdapter(Adapter):
+    name = "pi"
+
+    def run(self, request: SkillRunRequest) -> SkillRunResult:
+        return run_node_adapter(self.name, RUNNER, request)

--- a/experiments/sdk_benchmark/benchmark/cli.py
+++ b/experiments/sdk_benchmark/benchmark/cli.py
@@ -23,7 +23,6 @@ from .report import write_reports
 from .scenarios import load_scenarios
 from .scoring import score
 
-
 ADAPTERS: dict[str, type[Adapter]] = {
     "claude-agent-sdk": ClaudeAgentAdapter,
     "opencode": OpenCodeAdapter,

--- a/experiments/sdk_benchmark/benchmark/cli.py
+++ b/experiments/sdk_benchmark/benchmark/cli.py
@@ -36,16 +36,38 @@ def main(argv: list[str] | None = None) -> int:
 
     run = sub.add_parser("run", help="Run the benchmark")
     run.add_argument("--scenarios", type=Path, required=True)
-    run.add_argument("--skill", type=Path, required=True, help="Path to the skill directory (containing SKILL.md)")
+    run.add_argument(
+        "--skill",
+        type=Path,
+        required=True,
+        help="Path to the skill directory (containing SKILL.md)",
+    )
     run.add_argument("--model", default="claude-sonnet-4-6")
-    run.add_argument("--adapters", default="claude-agent-sdk,opencode,pi",
-                     help="Comma-separated subset of adapters to run.")
-    run.add_argument("--provider", default="anthropic", choices=["anthropic", "openrouter"],
-                     help="Routes auth + model naming. 'openrouter' expects OPENROUTER_API_KEY in env.")
-    run.add_argument("--out-dir", type=Path, default=Path(__file__).resolve().parent.parent / "results")
-    run.add_argument("--cwd", type=Path, default=None, help="Working directory for the agent. Defaults to skill parent.")
-    run.add_argument("--dry-run", action="store_true",
-                     help="Skip SDK calls; just verify scenarios load and adapters are reachable.")
+    run.add_argument(
+        "--adapters",
+        default="claude-agent-sdk,opencode,pi",
+        help="Comma-separated subset of adapters to run.",
+    )
+    run.add_argument(
+        "--provider",
+        default="anthropic",
+        choices=["anthropic", "openrouter"],
+        help="Routes auth + model naming. 'openrouter' expects OPENROUTER_API_KEY in env.",
+    )
+    run.add_argument(
+        "--out-dir", type=Path, default=Path(__file__).resolve().parent.parent / "results"
+    )
+    run.add_argument(
+        "--cwd",
+        type=Path,
+        default=None,
+        help="Working directory for the agent. Defaults to skill parent.",
+    )
+    run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Skip SDK calls; just verify scenarios load and adapters are reachable.",
+    )
 
     args = parser.parse_args(argv)
     if args.command != "run":
@@ -99,7 +121,9 @@ def main(argv: list[str] | None = None) -> int:
             rows.append((scenario, result, score_obj, cost))
             status = "OK" if score_obj.success else "FAIL"
             cost_str = f"${cost:.4f}" if cost is not None else "(no cost)"
-            print(f"  → {status} duration={result.duration_seconds:.1f}s cost={cost_str}", flush=True)
+            print(
+                f"  → {status} duration={result.duration_seconds:.1f}s cost={cost_str}", flush=True
+            )
 
     md_path, json_path = write_reports(args.out_dir, rows, args.model)
     print(f"\nReports written:\n  - {md_path}\n  - {json_path}")

--- a/experiments/sdk_benchmark/benchmark/cli.py
+++ b/experiments/sdk_benchmark/benchmark/cli.py
@@ -107,7 +107,21 @@ def main(argv: list[str] | None = None) -> int:
                 timeout_seconds=scenario.timeout_seconds,
                 provider=args.provider,
             )
-            result = adapter.run(request)
+            try:
+                result = adapter.run(request)
+            except Exception as exc:
+                # An unhandled adapter crash shouldn't sink the whole matrix —
+                # synthesize a failure row and keep going.
+                from .adapters.base import SkillRunResult
+
+                result = SkillRunResult(
+                    adapter=adapter_name,
+                    scenario_id=scenario.id,
+                    model=args.model,
+                    success=False,
+                    final_text="",
+                    error=f"adapter raised: {type(exc).__name__}: {exc}",
+                )
             cost = result.native_cost_usd
             if cost is None:
                 cost = cost_from_tokens(

--- a/experiments/sdk_benchmark/benchmark/cli.py
+++ b/experiments/sdk_benchmark/benchmark/cli.py
@@ -1,0 +1,133 @@
+"""Benchmark CLI.
+
+Usage:
+    python -m benchmark.cli run \\
+        --scenarios benchmark/scenarios.yaml \\
+        --skill ../../skills/root-cause-analysis \\
+        --model claude-sonnet-4-6 \\
+        --adapters claude-agent-sdk,opencode,pi
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from .adapters.base import Adapter, SkillRunRequest
+from .adapters.claude_agent import ClaudeAgentAdapter
+from .adapters.opencode import OpenCodeAdapter
+from .adapters.pi import PiAdapter
+from .pricing import cost_from_tokens
+from .report import write_reports
+from .scenarios import load_scenarios
+from .scoring import score
+
+
+ADAPTERS: dict[str, type[Adapter]] = {
+    "claude-agent-sdk": ClaudeAgentAdapter,
+    "opencode": OpenCodeAdapter,
+    "pi": PiAdapter,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="benchmark")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    run = sub.add_parser("run", help="Run the benchmark")
+    run.add_argument("--scenarios", type=Path, required=True)
+    run.add_argument("--skill", type=Path, required=True, help="Path to the skill directory (containing SKILL.md)")
+    run.add_argument("--model", default="claude-sonnet-4-6")
+    run.add_argument("--adapters", default="claude-agent-sdk,opencode,pi",
+                     help="Comma-separated subset of adapters to run.")
+    run.add_argument("--provider", default="anthropic", choices=["anthropic", "openrouter"],
+                     help="Routes auth + model naming. 'openrouter' expects OPENROUTER_API_KEY in env.")
+    run.add_argument("--out-dir", type=Path, default=Path(__file__).resolve().parent.parent / "results")
+    run.add_argument("--cwd", type=Path, default=None, help="Working directory for the agent. Defaults to skill parent.")
+    run.add_argument("--dry-run", action="store_true",
+                     help="Skip SDK calls; just verify scenarios load and adapters are reachable.")
+
+    args = parser.parse_args(argv)
+    if args.command != "run":
+        parser.error("unknown command")
+
+    scenarios = load_scenarios(args.scenarios)
+    adapter_names = [a.strip() for a in args.adapters.split(",") if a.strip()]
+    unknown = [a for a in adapter_names if a not in ADAPTERS]
+    if unknown:
+        parser.error(f"unknown adapter(s): {unknown}. Choose from {list(ADAPTERS)}")
+
+    if args.dry_run:
+        print(f"Loaded {len(scenarios)} scenarios:")
+        for s in scenarios:
+            print(f"  - {s.id}: {s.description}")
+        print(f"Selected adapters: {adapter_names}")
+        print(f"Skill directory: {args.skill.resolve()}")
+        return 0
+
+    if not (args.skill / "SKILL.md").exists():
+        parser.error(f"no SKILL.md at {args.skill}")
+
+    if args.provider == "openrouter":
+        _wire_openrouter_env()
+
+    rows = []
+    for adapter_name in adapter_names:
+        adapter = ADAPTERS[adapter_name]()
+        for scenario in scenarios:
+            print(f"[{adapter_name}] running {scenario.id}…", flush=True)
+            request = SkillRunRequest(
+                scenario_id=scenario.id,
+                prompt=scenario.prompt,
+                skill_path=args.skill,
+                model=args.model,
+                cwd=args.cwd,
+                timeout_seconds=scenario.timeout_seconds,
+                provider=args.provider,
+            )
+            result = adapter.run(request)
+            cost = result.native_cost_usd
+            if cost is None:
+                cost = cost_from_tokens(
+                    args.model,
+                    result.usage.input_tokens,
+                    result.usage.output_tokens,
+                    result.usage.cache_read_tokens,
+                    result.usage.cache_write_tokens,
+                )
+            score_obj = score(result, scenario, cost)
+            rows.append((scenario, result, score_obj, cost))
+            status = "OK" if score_obj.success else "FAIL"
+            cost_str = f"${cost:.4f}" if cost is not None else "(no cost)"
+            print(f"  → {status} duration={result.duration_seconds:.1f}s cost={cost_str}", flush=True)
+
+    md_path, json_path = write_reports(args.out_dir, rows, args.model)
+    print(f"\nReports written:\n  - {md_path}\n  - {json_path}")
+    return 0
+
+
+def _wire_openrouter_env() -> None:
+    """Route Claude Agent SDK at OpenRouter via ANTHROPIC_BASE_URL.
+
+    OpenCode and Pi pick up the provider from request.provider; they need
+    OPENROUTER_API_KEY in env, which the user already provides.
+
+    We unconditionally overwrite ANTHROPIC_* env vars: when this harness runs
+    inside another Claude Code process, those are pre-set to the parent's own
+    routing and would otherwise leak into the spawned `claude` subprocess.
+    """
+    import os
+
+    key = os.environ.get("OPENROUTER_API_KEY")
+    if not key:
+        raise SystemExit("--provider openrouter requires OPENROUTER_API_KEY in env")
+    os.environ["ANTHROPIC_BASE_URL"] = "https://openrouter.ai/api"
+    os.environ["ANTHROPIC_AUTH_TOKEN"] = key
+    # Per OpenRouter's Claude Code guide, blank ANTHROPIC_API_KEY so the SDK
+    # uses ANTHROPIC_AUTH_TOKEN instead.
+    os.environ["ANTHROPIC_API_KEY"] = ""
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/experiments/sdk_benchmark/benchmark/pricing.py
+++ b/experiments/sdk_benchmark/benchmark/pricing.py
@@ -1,0 +1,60 @@
+"""Token pricing table for cost estimation.
+
+Each adapter reports native cost when the SDK exposes it. When it doesn't, the
+harness falls back to multiplying observed token counts by these rates.
+
+Update PRICING when Anthropic publishes new pricing. Rates are USD per
+1,000,000 tokens.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelRate:
+    input_per_mtok: float
+    output_per_mtok: float
+    cache_read_per_mtok: float
+    cache_write_per_mtok: float
+
+
+PRICING: dict[str, ModelRate] = {
+    "claude-opus-4-7": ModelRate(15.00, 75.00, 1.50, 18.75),
+    "claude-opus-4-6": ModelRate(15.00, 75.00, 1.50, 18.75),
+    "claude-opus-4-5": ModelRate(15.00, 75.00, 1.50, 18.75),
+    "claude-opus-4-1": ModelRate(15.00, 75.00, 1.50, 18.75),
+    "claude-sonnet-4-6": ModelRate(3.00, 15.00, 0.30, 3.75),
+    "claude-sonnet-4-5": ModelRate(3.00, 15.00, 0.30, 3.75),
+    "claude-haiku-4-5": ModelRate(1.00, 5.00, 0.10, 1.25),
+}
+
+
+def cost_from_tokens(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_write_tokens: int = 0,
+) -> float | None:
+    """Compute USD cost from token counts. Returns None if the model is unknown."""
+    rate = PRICING.get(_normalize(model))
+    if rate is None:
+        return None
+    return (
+        input_tokens * rate.input_per_mtok
+        + output_tokens * rate.output_per_mtok
+        + cache_read_tokens * rate.cache_read_per_mtok
+        + cache_write_tokens * rate.cache_write_per_mtok
+    ) / 1_000_000
+
+
+def _normalize(model: str) -> str:
+    # Strip provider prefix and date suffix so both "anthropic/claude-sonnet-4.6"
+    # and "claude-sonnet-4-6-20250101" still match "claude-sonnet-4-6".
+    name = model.split("/")[-1].lower().replace(".", "-")
+    for key in PRICING:
+        if name.startswith(key):
+            return key
+    return name

--- a/experiments/sdk_benchmark/benchmark/report.py
+++ b/experiments/sdk_benchmark/benchmark/report.py
@@ -1,0 +1,110 @@
+"""Render benchmark results as Markdown + JSON."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime
+from pathlib import Path
+from statistics import mean
+
+from .adapters.base import SkillRunResult
+from .scenarios import Scenario
+from .scoring import Score
+
+
+def write_reports(
+    out_dir: Path,
+    rows: list[tuple[Scenario, SkillRunResult, Score, float | None]],
+    model: str,
+) -> tuple[Path, Path]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ts = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
+    json_path = out_dir / f"results-{ts}.json"
+    md_path = out_dir / f"results-{ts}.md"
+
+    json_path.write_text(json.dumps(_json_payload(rows, model), indent=2, default=str))
+    md_path.write_text(_markdown(rows, model))
+    return md_path, json_path
+
+
+def _json_payload(rows, model: str) -> dict:
+    return {
+        "model": model,
+        "timestamp_utc": datetime.utcnow().isoformat() + "Z",
+        "runs": [
+            {
+                "scenario": asdict(scenario),
+                "result": _result_to_dict(result),
+                "score": asdict(score_obj),
+                "cost_usd": cost,
+            }
+            for scenario, result, score_obj, cost in rows
+        ],
+    }
+
+
+def _result_to_dict(result: SkillRunResult) -> dict:
+    return {
+        "adapter": result.adapter,
+        "scenario_id": result.scenario_id,
+        "model": result.model,
+        "success_adapter_level": result.success,
+        "final_text": result.final_text,
+        "tool_calls": result.tool_calls,
+        "usage": asdict(result.usage),
+        "native_cost_usd": result.native_cost_usd,
+        "duration_seconds": result.duration_seconds,
+        "num_turns": result.num_turns,
+        "error": result.error,
+        "raw": result.raw,
+    }
+
+
+def _markdown(rows, model: str) -> str:
+    by_adapter: dict[str, list[tuple[Scenario, SkillRunResult, Score, float | None]]] = {}
+    for row in rows:
+        by_adapter.setdefault(row[1].adapter, []).append(row)
+
+    lines = [
+        "# SDK benchmark — root-cause-analysis",
+        "",
+        f"- **Model**: `{model}`",
+        f"- **Timestamp (UTC)**: {datetime.utcnow().isoformat()}Z",
+        f"- **Scenarios**: {len({r[0].id for r in rows})}",
+        f"- **Adapters**: {', '.join(sorted(by_adapter))}",
+        "",
+        "## Summary",
+        "",
+        "| Adapter | Runs | Success rate | Avg cost (USD) | Avg duration (s) | Avg turns |",
+        "|---|---|---|---|---|---|",
+    ]
+
+    for adapter, items in sorted(by_adapter.items()):
+        n = len(items)
+        success_rate = sum(1 for _, _, s, _ in items if s.success) / n
+        costs = [c for _, _, _, c in items if c is not None]
+        avg_cost = mean(costs) if costs else float("nan")
+        avg_duration = mean(r.duration_seconds for _, r, _, _ in items)
+        avg_turns = mean(r.num_turns for _, r, _, _ in items)
+        lines.append(
+            f"| `{adapter}` | {n} | {success_rate:.0%} | {avg_cost:.4f} | {avg_duration:.1f} | {avg_turns:.1f} |"
+        )
+
+    lines.extend(["", "## Per-scenario detail", ""])
+    for adapter in sorted(by_adapter):
+        lines.append(f"### `{adapter}`")
+        lines.append("")
+        lines.append("| Scenario | Success | Cost (USD) | Duration (s) | Turns | Keywords hit | Notes |")
+        lines.append("|---|---|---|---|---|---|---|")
+        for scenario, result, score_obj, cost in by_adapter[adapter]:
+            cost_str = f"{cost:.4f}" if cost is not None else "—"
+            kw = f"{len(score_obj.keyword_hits)}/{len(scenario.expected_keywords)}"
+            notes = "; ".join(score_obj.notes) or "—"
+            lines.append(
+                f"| {scenario.id} | {'✅' if score_obj.success else '❌'} | {cost_str} | "
+                f"{result.duration_seconds:.1f} | {result.num_turns} | {kw} | {notes} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)

--- a/experiments/sdk_benchmark/benchmark/report.py
+++ b/experiments/sdk_benchmark/benchmark/report.py
@@ -95,7 +95,9 @@ def _markdown(rows, model: str) -> str:
     for adapter in sorted(by_adapter):
         lines.append(f"### `{adapter}`")
         lines.append("")
-        lines.append("| Scenario | Success | Cost (USD) | Duration (s) | Turns | Keywords hit | Notes |")
+        lines.append(
+            "| Scenario | Success | Cost (USD) | Duration (s) | Turns | Keywords hit | Notes |"
+        )
         lines.append("|---|---|---|---|---|---|---|")
         for scenario, result, score_obj, cost in by_adapter[adapter]:
             cost_str = f"{cost:.4f}" if cost is not None else "—"

--- a/experiments/sdk_benchmark/benchmark/runners/opencode_runner.mjs
+++ b/experiments/sdk_benchmark/benchmark/runners/opencode_runner.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// OpenCode runner — invokes the `opencode run --format json` CLI and parses
+// its JSON event stream. The OpenCode TypeScript SDK is essentially a thin
+// HTTP client around the same `opencode serve` process; for benchmark use
+// the CLI is faster (no server spin-up) and emits per-step token + cost.
+
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const payload = JSON.parse(readFileSync(0, "utf8"));
+const started = process.hrtime.bigint();
+
+const here = dirname(fileURLToPath(import.meta.url));
+const opencodeBin = resolve(here, "..", "..", "node_modules", ".bin", "opencode");
+
+// Model format: "openrouter/anthropic/claude-sonnet-4.6" or "anthropic/claude-sonnet-4-6".
+const modelArg = payload.provider === "openrouter"
+  ? `openrouter/${payload.model}`
+  : `anthropic/${payload.model}`;
+
+const args = [
+  "run",
+  "--format=json",
+  "--dangerously-skip-permissions",
+  "-m", modelArg,
+  // Prepend the skill body as a user "system instructions" preamble. OpenCode
+  // doesn't expose a `--system` flag at the CLI, so we inline it.
+  `[SYSTEM]\n${payload.systemPrompt}\n[/SYSTEM]\n\n${payload.prompt}`,
+];
+
+const usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+let nativeCostUsd = 0;
+let finalText = "";
+const toolCalls = [];
+let numTurns = 0;
+let error = null;
+
+try {
+  const result = await runOpencode(opencodeBin, args, payload);
+  for (const ev of result.events) {
+    if (ev.type === "text" && ev.part?.text) finalText += ev.part.text;
+    if (ev.type === "tool_use" || ev.type === "tool") {
+      const name = ev.part?.tool ?? ev.part?.name;
+      if (name) toolCalls.push(name);
+    }
+    if (ev.type === "step_finish" && ev.part?.tokens) {
+      const t = ev.part.tokens;
+      usage.input += t.input ?? 0;
+      usage.output += t.output ?? 0;
+      usage.cacheRead += t.cache?.read ?? 0;
+      usage.cacheWrite += t.cache?.write ?? 0;
+      if (typeof ev.part.cost === "number") nativeCostUsd += ev.part.cost;
+      numTurns += 1;
+    }
+  }
+  if (result.stderr && !finalText) {
+    error = result.stderr.trim().split("\n").slice(-1)[0] || null;
+  }
+  if (result.exitCode !== 0 && !finalText) {
+    error = error ?? `opencode exited ${result.exitCode}`;
+  }
+} catch (err) {
+  error = `${err.name}: ${err.message}`;
+}
+
+const durationSeconds = Number(process.hrtime.bigint() - started) / 1e9;
+emit({
+  finalText,
+  toolCalls,
+  usage,
+  nativeCostUsd: nativeCostUsd > 0 ? nativeCostUsd : null,
+  durationSeconds,
+  numTurns,
+  error,
+});
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+function runOpencode(bin, args, payload) {
+  return new Promise((resolveP) => {
+    const proc = spawn(bin, args, {
+      env: process.env,
+      cwd: payload.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    const events = [];
+    const killer = setTimeout(() => proc.kill("SIGTERM"), (payload.timeoutSeconds + 10) * 1000);
+    proc.stdout.on("data", (chunk) => {
+      stdoutBuf += chunk.toString();
+      let nl;
+      while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+        const line = stdoutBuf.slice(0, nl);
+        stdoutBuf = stdoutBuf.slice(nl + 1);
+        if (!line.trim()) continue;
+        try { events.push(JSON.parse(line)); } catch (_e) { /* ignore non-JSON */ }
+      }
+    });
+    proc.stderr.on("data", (chunk) => { stderrBuf += chunk.toString(); });
+    proc.on("close", (code) => {
+      clearTimeout(killer);
+      resolveP({ exitCode: code ?? 1, events, stderr: stderrBuf });
+    });
+  });
+}

--- a/experiments/sdk_benchmark/benchmark/runners/opencode_runner.mjs
+++ b/experiments/sdk_benchmark/benchmark/runners/opencode_runner.mjs
@@ -55,11 +55,15 @@ try {
       numTurns += 1;
     }
   }
-  if (result.stderr && !finalText) {
+  if (result.exitCode !== 0) {
+    // Non-zero exit is always a failure — even if some text streamed before the
+    // crash, the run can't be trusted. Prefer the last stderr line as the error
+    // string since it's usually the actual reason.
+    const stderrTail = result.stderr?.trim().split("\n").slice(-1)[0];
+    error = error ?? stderrTail ?? `opencode exited ${result.exitCode}`;
+  } else if (result.stderr && !finalText) {
+    // Successful exit with stderr noise and no text → surface stderr.
     error = result.stderr.trim().split("\n").slice(-1)[0] || null;
-  }
-  if (result.exitCode !== 0 && !finalText) {
-    error = error ?? `opencode exited ${result.exitCode}`;
   }
 } catch (err) {
   error = `${err.name}: ${err.message}`;
@@ -82,14 +86,22 @@ function emit(obj) {
 
 function runOpencode(bin, args, payload) {
   return new Promise((resolveP) => {
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    const events = [];
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killer);
+      resolveP(result);
+    };
+
     const proc = spawn(bin, args, {
       env: process.env,
       cwd: payload.cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    let stdoutBuf = "";
-    let stderrBuf = "";
-    const events = [];
     const killer = setTimeout(() => proc.kill("SIGTERM"), (payload.timeoutSeconds + 10) * 1000);
     proc.stdout.on("data", (chunk) => {
       stdoutBuf += chunk.toString();
@@ -102,9 +114,13 @@ function runOpencode(bin, args, payload) {
       }
     });
     proc.stderr.on("data", (chunk) => { stderrBuf += chunk.toString(); });
+    // spawn() emits 'error' (and not 'close') when the binary can't be
+    // exec'd (ENOENT, EACCES) — without this handler the Promise hangs.
+    proc.on("error", (err) => {
+      finish({ exitCode: 1, events, stderr: `${stderrBuf}spawn error: ${err.message}` });
+    });
     proc.on("close", (code) => {
-      clearTimeout(killer);
-      resolveP({ exitCode: code ?? 1, events, stderr: stderrBuf });
+      finish({ exitCode: code ?? 1, events, stderr: stderrBuf });
     });
   });
 }

--- a/experiments/sdk_benchmark/benchmark/runners/pi_runner.mjs
+++ b/experiments/sdk_benchmark/benchmark/runners/pi_runner.mjs
@@ -25,6 +25,8 @@ let nativeCostUsd = null;
 let numTurns = 0;
 let error = null;
 
+let session = null;
+let unsub = null;
 try {
   const authStorage = AuthStorage.create();
 
@@ -45,7 +47,7 @@ try {
     throw new Error(`Model not found: provider=${provider} id=${modelId}`);
   }
 
-  const { session } = await createAgentSession({
+  const created = await createAgentSession({
     sessionManager: SessionManager.inMemory(),
     authStorage,
     modelRegistry,
@@ -53,8 +55,9 @@ try {
     cwd: payload.cwd,
     systemPrompt: payload.systemPrompt,
   });
+  session = created.session;
 
-  const unsub = session.subscribe?.((event) => {
+  unsub = session.subscribe?.((event) => {
     if (event?.type === "message_update") {
       const sub = event.assistantMessageEvent;
       if (!sub) return;
@@ -66,8 +69,6 @@ try {
   });
 
   await session.prompt(payload.prompt);
-
-  if (typeof unsub === "function") unsub();
 
   // session.getSessionStats() is the documented API — returns SessionStats with
   // { tokens: {input, output, cacheRead, cacheWrite, total}, cost, toolCalls, ... }.
@@ -99,10 +100,16 @@ try {
       }
     }
   }
-
-  session.dispose?.();
 } catch (err) {
   error = `${err.name}: ${err.message}`;
+} finally {
+  // Always release the event subscription and dispose the session, even when
+  // an error short-circuited the happy path. Otherwise back-to-back benchmark
+  // runs leak file handles and event listeners.
+  if (typeof unsub === "function") {
+    try { unsub(); } catch (_e) { /* swallow — cleanup */ }
+  }
+  try { session?.dispose?.(); } catch (_e) { /* swallow — cleanup */ }
 }
 
 const durationSeconds = Number(process.hrtime.bigint() - started) / 1e9;

--- a/experiments/sdk_benchmark/benchmark/runners/pi_runner.mjs
+++ b/experiments/sdk_benchmark/benchmark/runners/pi_runner.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Pi Coding Agent SDK runner — JSON-on-stdin / JSON-on-stdout contract.
+
+import { readFileSync } from "node:fs";
+
+const payload = JSON.parse(readFileSync(0, "utf8"));
+const started = process.hrtime.bigint();
+
+let mod, piAi;
+try {
+  mod = await import("@earendil-works/pi-coding-agent");
+  piAi = await import("@earendil-works/pi-ai");
+} catch (err) {
+  emit({ error: `Pi SDK not installed: ${err.message}.` });
+  process.exit(0);
+}
+
+const { AuthStorage, ModelRegistry, SessionManager, createAgentSession } = mod;
+const { getModel } = piAi;
+
+const toolCalls = [];
+let finalText = "";
+const usage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+let nativeCostUsd = null;
+let numTurns = 0;
+let error = null;
+
+try {
+  const authStorage = AuthStorage.create();
+
+  if (payload.provider === "openrouter") {
+    const key = process.env.OPENROUTER_API_KEY;
+    if (!key) throw new Error("OPENROUTER_API_KEY not set");
+    authStorage.setRuntimeApiKey("openrouter", key);
+  }
+
+  const modelRegistry = ModelRegistry.create(authStorage);
+
+  // For OpenRouter: model id is e.g. "anthropic/claude-sonnet-4.6" under provider "openrouter".
+  // For Anthropic direct: provider="anthropic", id="claude-sonnet-4-6".
+  const provider = payload.provider === "openrouter" ? "openrouter" : "anthropic";
+  const modelId = payload.model;
+  let model = getModel(provider, modelId) ?? modelRegistry.find(provider, modelId);
+  if (!model) {
+    throw new Error(`Model not found: provider=${provider} id=${modelId}`);
+  }
+
+  const { session } = await createAgentSession({
+    sessionManager: SessionManager.inMemory(),
+    authStorage,
+    modelRegistry,
+    model,
+    cwd: payload.cwd,
+    systemPrompt: payload.systemPrompt,
+  });
+
+  const unsub = session.subscribe?.((event) => {
+    if (event?.type === "message_update") {
+      const sub = event.assistantMessageEvent;
+      if (!sub) return;
+      if (sub.type === "text_delta") finalText += sub.delta ?? "";
+      if (sub.type === "tool_call" || sub.type === "tool_use") {
+        toolCalls.push(sub.name ?? sub.tool ?? "unknown");
+      }
+    }
+  });
+
+  await session.prompt(payload.prompt);
+
+  if (typeof unsub === "function") unsub();
+
+  // session.getSessionStats() is the documented API — returns SessionStats with
+  // { tokens: {input, output, cacheRead, cacheWrite, total}, cost, toolCalls, ... }.
+  const stats = typeof session.getSessionStats === "function" ? session.getSessionStats() : {};
+  const tokens = stats.tokens ?? {};
+  usage.input = tokens.input ?? 0;
+  usage.output = tokens.output ?? 0;
+  usage.cacheRead = tokens.cacheRead ?? 0;
+  usage.cacheWrite = tokens.cacheWrite ?? 0;
+  nativeCostUsd = typeof stats.cost === "number" ? stats.cost : null;
+  numTurns = stats.assistantMessages ?? (session.messages ?? []).length;
+  // Pi reports a tool-call count, not a per-call list, unless we caught them
+  // via the subscribe stream above. Pad toolCalls with anonymous entries so
+  // counts in the report are at least accurate.
+  if (toolCalls.length === 0 && typeof stats.toolCalls === "number") {
+    for (let i = 0; i < stats.toolCalls; i++) toolCalls.push("tool");
+  }
+
+  if (!finalText) {
+    const msgs = session.messages ?? [];
+    const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
+    if (lastAssistant) {
+      if (typeof lastAssistant.content === "string") finalText = lastAssistant.content;
+      else if (Array.isArray(lastAssistant.content)) {
+        finalText = lastAssistant.content
+          .filter((c) => c.type === "text")
+          .map((c) => c.text)
+          .join("");
+      }
+    }
+  }
+
+  session.dispose?.();
+} catch (err) {
+  error = `${err.name}: ${err.message}`;
+}
+
+const durationSeconds = Number(process.hrtime.bigint() - started) / 1e9;
+emit({
+  finalText,
+  toolCalls,
+  usage,
+  nativeCostUsd,
+  durationSeconds,
+  numTurns,
+  error,
+});
+
+function emit(obj) {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}

--- a/experiments/sdk_benchmark/benchmark/scenarios-light.yaml
+++ b/experiments/sdk_benchmark/benchmark/scenarios-light.yaml
@@ -1,0 +1,41 @@
+# Lightweight scenarios for benchmarking without RHDP infrastructure.
+# These exercise reasoning + simple tool use but should never need the
+# SSH jumpbox, Splunk, or GitHub MCP.
+
+- id: refuses-without-job-id
+  description: Agent should NOT fabricate a job ID; should ask for one or refuse.
+  prompt: |
+    Investigate the failed AAP job.
+  expected_keywords:
+    - job
+  expected_tool_calls: []
+  forbidden_tool_calls: []
+  max_cost_usd: 0.50
+  timeout_seconds: 90
+
+- id: explains-skill
+  description: Agent should describe what the root-cause-analysis skill does from its loaded instructions.
+  prompt: |
+    In 2-3 sentences, what does this root-cause-analysis skill do and what
+    inputs does it need? Do not run any commands — just summarize from the
+    instructions you have.
+  expected_keywords:
+    - root cause
+    - job
+  expected_tool_calls: []
+  forbidden_tool_calls: []
+  max_cost_usd: 0.50
+  timeout_seconds: 90
+
+- id: lists-prereqs
+  description: Agent should list the skill's prerequisites without trying to run them.
+  prompt: |
+    List the prerequisites this skill needs in order to run a real analysis.
+    Do NOT execute setup. Just list them as bullets.
+  expected_keywords:
+    - splunk
+    - github
+  expected_tool_calls: []
+  forbidden_tool_calls: []
+  max_cost_usd: 0.50
+  timeout_seconds: 90

--- a/experiments/sdk_benchmark/benchmark/scenarios-light.yaml
+++ b/experiments/sdk_benchmark/benchmark/scenarios-light.yaml
@@ -1,6 +1,10 @@
 # Lightweight scenarios for benchmarking without RHDP infrastructure.
 # These exercise reasoning + simple tool use but should never need the
 # SSH jumpbox, Splunk, or GitHub MCP.
+#
+# `forbidden_tool_calls` is set on each scenario because the prompts say
+# "do not run commands" — if the agent reaches for Bash/Read/etc anyway,
+# the run should fail the scoring.
 
 - id: refuses-without-job-id
   description: Agent should NOT fabricate a job ID; should ask for one or refuse.
@@ -9,7 +13,7 @@
   expected_keywords:
     - job
   expected_tool_calls: []
-  forbidden_tool_calls: []
+  forbidden_tool_calls: [Bash, Read, Write, Edit, Grep, Glob]
   max_cost_usd: 0.50
   timeout_seconds: 90
 
@@ -23,7 +27,7 @@
     - root cause
     - job
   expected_tool_calls: []
-  forbidden_tool_calls: []
+  forbidden_tool_calls: [Bash, Read, Write, Edit, Grep, Glob]
   max_cost_usd: 0.50
   timeout_seconds: 90
 
@@ -36,6 +40,6 @@
     - splunk
     - github
   expected_tool_calls: []
-  forbidden_tool_calls: []
+  forbidden_tool_calls: [Bash, Read, Write, Edit, Grep, Glob]
   max_cost_usd: 0.50
   timeout_seconds: 90

--- a/experiments/sdk_benchmark/benchmark/scenarios.py
+++ b/experiments/sdk_benchmark/benchmark/scenarios.py
@@ -1,0 +1,30 @@
+"""Scenario schema + loader."""
+
+from __future__ import annotations
+
+import yaml
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Scenario:
+    id: str
+    description: str
+    prompt: str
+    expected_keywords: list[str] = field(default_factory=list)
+    expected_tool_calls: list[str] = field(default_factory=list)
+    forbidden_tool_calls: list[str] = field(default_factory=list)
+    max_cost_usd: float = 5.0
+    timeout_seconds: int = 600
+
+
+def load_scenarios(path: Path) -> list[Scenario]:
+    with path.open() as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, list):
+        raise ValueError(f"{path} must contain a YAML list of scenarios")
+    scenarios = []
+    for entry in raw:
+        scenarios.append(Scenario(**entry))
+    return scenarios

--- a/experiments/sdk_benchmark/benchmark/scenarios.py
+++ b/experiments/sdk_benchmark/benchmark/scenarios.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import yaml
 
 
 @dataclass

--- a/experiments/sdk_benchmark/benchmark/scenarios.yaml
+++ b/experiments/sdk_benchmark/benchmark/scenarios.yaml
@@ -1,0 +1,55 @@
+# RCA benchmark scenarios.
+#
+# Each scenario sends `prompt` to the agent (with the root-cause-analysis
+# SKILL.md as system prompt). The agent succeeds when it produces a diagnosis
+# containing all `expected_keywords`, calls each tool in `expected_tool_calls`
+# at least once, and stays under `max_cost_usd`.
+#
+# IMPORTANT: These prompts assume the agent has access to your RHDP
+# environment (SSH jumpbox, Splunk, GitHub MCP). Tune job IDs, keywords, and
+# expected tool calls to match real failures you have ground truth for.
+
+- id: preflight-only
+  description: Agent should run setup/preflight and report what's missing — works without any real RCA infra.
+  prompt: |
+    Run the root-cause-analysis preflight check and tell me exactly which
+    prerequisites are configured and which are missing. Do not start an
+    analysis.
+  expected_keywords:
+    - preflight
+  expected_tool_calls:
+    - Bash
+  forbidden_tool_calls: []
+  max_cost_usd: 0.50
+  timeout_seconds: 180
+
+- id: missing-job-id
+  description: Agent should refuse / ask when given no job ID rather than hallucinating one.
+  prompt: |
+    Investigate the failed AAP job.
+  expected_keywords:
+    - job
+  expected_tool_calls: []
+  forbidden_tool_calls: []
+  max_cost_usd: 0.25
+  timeout_seconds: 120
+
+# Replace <REAL_JOB_ID> and tune expected_keywords once you have a ground-truth
+# failure. The agent has access to scripts/cli.py inside the skill directory.
+- id: real-job-analysis
+  description: End-to-end RCA on a known failed job. Requires JUMPBOX_URI, Splunk creds, and (optional) GitHub MCP.
+  prompt: |
+    Perform a full root-cause analysis for AAP job <REAL_JOB_ID>. Use the
+    skill's scripts to fetch logs, correlate with Splunk, and pull related
+    configuration from GitHub. Produce a diagnosis with: (1) the primary root
+    cause, (2) supporting evidence, (3) confidence level.
+  expected_keywords:
+    # Fill these in with the substantive terms you'd expect in a correct
+    # diagnosis — e.g. "ssl handshake", "selinux", "quota exceeded".
+    - root cause
+    - confidence
+  expected_tool_calls:
+    - Bash
+  forbidden_tool_calls: []
+  max_cost_usd: 5.00
+  timeout_seconds: 900

--- a/experiments/sdk_benchmark/benchmark/scenarios.yaml
+++ b/experiments/sdk_benchmark/benchmark/scenarios.yaml
@@ -30,7 +30,8 @@
   expected_keywords:
     - job
   expected_tool_calls: []
-  forbidden_tool_calls: []
+  # Refusal/clarification path — the agent shouldn't reach for any tool.
+  forbidden_tool_calls: [Bash, Read, Write, Edit, Grep, Glob]
   max_cost_usd: 0.25
   timeout_seconds: 120
 

--- a/experiments/sdk_benchmark/benchmark/scoring.py
+++ b/experiments/sdk_benchmark/benchmark/scoring.py
@@ -48,10 +48,7 @@ def score(result: SkillRunResult, scenario: Scenario, cost_usd: float | None) ->
         notes.append(f"cost ${cost_usd:.4f} exceeded budget ${scenario.max_cost_usd:.4f}")
 
     success = bool(
-        result.error is None
-        and not keyword_misses
-        and not forbidden
-        and not over_budget
+        result.error is None and not keyword_misses and not forbidden and not over_budget
     )
 
     return Score(

--- a/experiments/sdk_benchmark/benchmark/scoring.py
+++ b/experiments/sdk_benchmark/benchmark/scoring.py
@@ -20,7 +20,7 @@ class Score:
     forbidden_tool_calls: list[str]
     over_budget: bool
     success: bool
-    """Composite: completed AND all expected keywords found AND no forbidden tools AND under budget."""
+    """Composite: completed AND all expected keywords found AND all expected tools called AND no forbidden tools AND under budget."""
 
     notes: list[str]
 
@@ -42,13 +42,19 @@ def score(result: SkillRunResult, scenario: Scenario, cost_usd: float | None) ->
         notes.append(f"adapter error: {result.error}")
     if keyword_misses:
         notes.append(f"missing keywords: {', '.join(keyword_misses)}")
+    if tool_misses:
+        notes.append(f"missing expected tools: {', '.join(tool_misses)}")
     if forbidden:
         notes.append(f"called forbidden tools: {', '.join(forbidden)}")
     if over_budget:
         notes.append(f"cost ${cost_usd:.4f} exceeded budget ${scenario.max_cost_usd:.4f}")
 
     success = bool(
-        result.error is None and not keyword_misses and not forbidden and not over_budget
+        result.error is None
+        and not keyword_misses
+        and not tool_misses
+        and not forbidden
+        and not over_budget
     )
 
     return Score(

--- a/experiments/sdk_benchmark/benchmark/scoring.py
+++ b/experiments/sdk_benchmark/benchmark/scoring.py
@@ -1,0 +1,67 @@
+"""Score a SkillRunResult against a Scenario."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .adapters.base import SkillRunResult
+from .scenarios import Scenario
+
+
+@dataclass
+class Score:
+    completed: bool
+    """Adapter returned without an SDK-level error."""
+
+    keyword_hits: list[str]
+    keyword_misses: list[str]
+    tool_hits: list[str]
+    tool_misses: list[str]
+    forbidden_tool_calls: list[str]
+    over_budget: bool
+    success: bool
+    """Composite: completed AND all expected keywords found AND no forbidden tools AND under budget."""
+
+    notes: list[str]
+
+
+def score(result: SkillRunResult, scenario: Scenario, cost_usd: float | None) -> Score:
+    text = result.final_text.lower()
+    keyword_hits = [k for k in scenario.expected_keywords if k.lower() in text]
+    keyword_misses = [k for k in scenario.expected_keywords if k.lower() not in text]
+
+    called = set(result.tool_calls)
+    tool_hits = [t for t in scenario.expected_tool_calls if t in called]
+    tool_misses = [t for t in scenario.expected_tool_calls if t not in called]
+    forbidden = [t for t in scenario.forbidden_tool_calls if t in called]
+
+    over_budget = cost_usd is not None and cost_usd > scenario.max_cost_usd
+
+    notes: list[str] = []
+    if result.error:
+        notes.append(f"adapter error: {result.error}")
+    if keyword_misses:
+        notes.append(f"missing keywords: {', '.join(keyword_misses)}")
+    if forbidden:
+        notes.append(f"called forbidden tools: {', '.join(forbidden)}")
+    if over_budget:
+        notes.append(f"cost ${cost_usd:.4f} exceeded budget ${scenario.max_cost_usd:.4f}")
+
+    success = bool(
+        result.error is None
+        and not keyword_misses
+        and not forbidden
+        and not over_budget
+    )
+
+    return Score(
+        completed=result.error is None,
+        keyword_hits=keyword_hits,
+        keyword_misses=keyword_misses,
+        tool_hits=tool_hits,
+        tool_misses=tool_misses,
+        forbidden_tool_calls=forbidden,
+        over_budget=over_budget,
+        success=success,
+        notes=notes,
+    )

--- a/experiments/sdk_benchmark/benchmark/skill_loader.py
+++ b/experiments/sdk_benchmark/benchmark/skill_loader.py
@@ -1,0 +1,20 @@
+"""Read a SKILL.md and return its body without YAML frontmatter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def skill_body(skill_dir: Path) -> str:
+    """Return the body of `<skill_dir>/SKILL.md` with frontmatter stripped.
+
+    Skills include the base path implicitly. We replace `{skill_path}` placeholder
+    if present so each SDK sees an absolute path it can use in Bash commands.
+    """
+    md = (skill_dir / "SKILL.md").read_text()
+    if md.startswith("---"):
+        _, _, rest = md.partition("---\n")
+        _, _, body = rest.partition("\n---\n")
+    else:
+        body = md
+    return body.replace("{skill_path}", str(skill_dir.resolve()))

--- a/experiments/sdk_benchmark/benchmark/skill_loader.py
+++ b/experiments/sdk_benchmark/benchmark/skill_loader.py
@@ -12,9 +12,23 @@ def skill_body(skill_dir: Path) -> str:
     if present so each SDK sees an absolute path it can use in Bash commands.
     """
     md = (skill_dir / "SKILL.md").read_text()
-    if md.startswith("---"):
-        _, _, rest = md.partition("---\n")
-        _, _, body = rest.partition("\n---\n")
-    else:
-        body = md
+    body = _strip_frontmatter(md, skill_dir / "SKILL.md")
     return body.replace("{skill_path}", str(skill_dir.resolve()))
+
+
+def _strip_frontmatter(md: str, path: Path) -> str:
+    """Remove a leading YAML frontmatter block.
+
+    Tolerates trailing whitespace on the fence lines and either Unix or
+    Windows line endings. If no opening fence is present, returns ``md`` as is.
+    Raises if an opening fence is present but no matching closing fence is
+    found — that indicates a malformed SKILL.md, not an intentionally
+    fence-less body, and silently dropping the body would mask the bug.
+    """
+    lines = md.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return md
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[i + 1 :])
+    raise ValueError(f"Malformed frontmatter in {path}: opening '---' has no closing fence")

--- a/experiments/sdk_benchmark/package-lock.json
+++ b/experiments/sdk_benchmark/package-lock.json
@@ -1,0 +1,2020 @@
+{
+  "name": "rhdp-rca-sdk-benchmark",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rhdp-rca-sdk-benchmark",
+      "version": "0.1.0",
+      "dependencies": {
+        "@earendil-works/pi-coding-agent": "*",
+        "@opencode-ai/sdk": "*",
+        "opencode-ai": "^1.15.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1049.0.tgz",
+      "integrity": "sha512-YM8b2baoRY8ul47b4amQW2VlUthLmM8DnqdlGO20LJmmmRpjnT91SaQJai3OMehA6uE0Gig88VyDCT1vEACSww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-node": "^3.972.43",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.20",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
+      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
+      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
+      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
+      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-login": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
+      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
+      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.38",
+        "@aws-sdk/credential-provider-http": "^3.972.40",
+        "@aws-sdk/credential-provider-ini": "^3.972.42",
+        "@aws-sdk/credential-provider-process": "^3.972.38",
+        "@aws-sdk/credential-provider-sso": "^3.972.42",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
+      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
+      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/token-providers": "3.1049.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
+      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.20.tgz",
+      "integrity": "sha512-LM6P0i+Lu6pi25oNw2nqxjRxiEOtLgPB7xIvHfa+FxHTRLg8wcgqu3qg2COl4QaT7Es2yCxYdeRLVYazKAwL8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
+      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1049.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
+      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.12",
+        "@aws-sdk/nested-clients": "^3.997.10",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.75.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.3.tgz",
+      "integrity": "sha512-azg09GSrckQa3ffbH09YEZC7DyHgmNSX+vmWEoEhQvp4icbzqbqLfIeMayMNEK/aGusm1SghZC4bPlDdagDALg==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.75.3",
+        "ignore": "^7.0.5",
+        "typebox": "^1.1.24",
+        "yaml": "^2.8.2"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.75.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.3.tgz",
+      "integrity": "sha512-UKccS+ADlkSVJ49a00346jUfXmUi6zzzB+pPWotsyA6SxhKr2ejjkGQksGyR1DyNVrsEP/WWlsOSTUUwVlzNaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "^3.1030.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "^2.2.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "typebox": "^1.1.24"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.75.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.3.tgz",
+      "integrity": "sha512-LIi5/CdUBfcLp3BAtpLx1BfnHDLmDOQVdzYfS1H9fjjCw2dcPr9voSI5ncrhvZdgyFSnfHck4BCbNcfZk+TEHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.75.3",
+        "@earendil-works/pi-ai": "^0.75.3",
+        "@earendil-works/pi-tui": "^0.75.3",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "chalk": "^5.5.0",
+        "cross-spawn": "^7.0.6",
+        "diff": "^8.0.2",
+        "glob": "^13.0.1",
+        "highlight.js": "^10.7.3",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "jiti": "^2.7.0",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "typebox": "^1.1.24",
+        "undici": "^8.3.0",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.6"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.75.3",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.3.tgz",
+      "integrity": "sha512-UbhtCsae+b3Y8/ZxtBPhiOrkD66gOHvJbfvLZwhBBsNtQuvUkZY5t9MQwmb8QcDYkFRnXHaq3FcEy1hjRSfj6w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
+      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
+        "@mariozechner/clipboard-darwin-universal": "0.3.6",
+        "@mariozechner/clipboard-darwin-x64": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
+      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
+      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
+      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
+      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
+      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
+      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
+      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
+      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
+      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
+      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mistralai/mistralai": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.15.5.tgz",
+      "integrity": "sha512-ozJuEmXzrOvia5n0L1KAuvpyf9ESGmTk1FiPhn0RK5X1whbzjlTXL0NAxqNCEkqETxL35jS1KHArEiTpvtJ6FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/koffi": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
+      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://liberapay.com/Koromix"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/opencode-ai": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-ai/-/opencode-ai-1.15.5.tgz",
+      "integrity": "sha512-ud/0sYo9h2BJALwLudRrzs551YJoi+rHo66jEsSLdOBv5RJxmN64aqqGaafhWxvgtaHyEOqfKnZPyx9GVKl/UA==",
+      "cpu": [
+        "arm64",
+        "x64"
+      ],
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "opencode": "bin/opencode.exe"
+      },
+      "optionalDependencies": {
+        "opencode-darwin-arm64": "1.15.5",
+        "opencode-darwin-x64": "1.15.5",
+        "opencode-darwin-x64-baseline": "1.15.5",
+        "opencode-linux-arm64": "1.15.5",
+        "opencode-linux-arm64-musl": "1.15.5",
+        "opencode-linux-x64": "1.15.5",
+        "opencode-linux-x64-baseline": "1.15.5",
+        "opencode-linux-x64-baseline-musl": "1.15.5",
+        "opencode-linux-x64-musl": "1.15.5",
+        "opencode-windows-arm64": "1.15.5",
+        "opencode-windows-x64": "1.15.5",
+        "opencode-windows-x64-baseline": "1.15.5"
+      }
+    },
+    "node_modules/opencode-darwin-arm64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-arm64/-/opencode-darwin-arm64-1.15.5.tgz",
+      "integrity": "sha512-gv8o3WbbW33SbmJvx/enDuZewlIoWfduSFo8M/WqlRwwO//33Rs3bgSnY21a6DYtXFL7NFzXO7QOmbPY5y02Jg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64/-/opencode-darwin-x64-1.15.5.tgz",
+      "integrity": "sha512-yuglSeJbTF4jRHmFgqteQUMCRLjVOQ1aqMaeevDNyJXOUZPWCdFG1h8Fq8dZBgBfPfBEpQNFEWv8D9DU3ycytg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-darwin-x64-baseline": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-darwin-x64-baseline/-/opencode-darwin-x64-baseline-1.15.5.tgz",
+      "integrity": "sha512-ROtf2AO2jXcH95280hJoVF+84kB7IGYrUb7WPG4jKYescf5a6CTq28Pr+l5csM0iBXHFR21qGS8ezZegI5K70A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/opencode-linux-arm64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64/-/opencode-linux-arm64-1.15.5.tgz",
+      "integrity": "sha512-y2K5gT0IPWXx5DSy9hw+h0vSTahbdEV8spK/oZ4iwCY/Px/wdVpk5IphgkHcEes/9fIR1oLmu0/HF/SHhWRMxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-arm64-musl": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-arm64-musl/-/opencode-linux-arm64-musl-1.15.5.tgz",
+      "integrity": "sha512-oBu8lSERTw6yX0umyBGzCiS9FLVpWnaHAwk7WFvN7FY9LsTEh4NfgiMdKBVtPmn14RwaWK8AHtjueJ2UvIMzlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64/-/opencode-linux-x64-1.15.5.tgz",
+      "integrity": "sha512-Y3arLZezt8a6Ed2fdwrD21+JSQeNCZmfqHqYCv5iMzcpkE8/a8TLkDQVre74zjA7Gxelyk2sjk4b6ZKMuWHIkw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline/-/opencode-linux-x64-baseline-1.15.5.tgz",
+      "integrity": "sha512-WgyIU/uAYxE4kTOWWmiaJ07hT8wLmlNMG0l9EjpeW70G8USn8EfCVZStGsKnOIMdb2KAX+b6phnC1ihROcDCvw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-baseline-musl": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-baseline-musl/-/opencode-linux-x64-baseline-musl-1.15.5.tgz",
+      "integrity": "sha512-EZ3sela0UkWV+jwE2gi7I89hhHFRUigUN36md1k3G45zM5epsrLnJYFbSk8bnMFfy5t32AsLufOw5dnlkfsYTw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-linux-x64-musl": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-linux-x64-musl/-/opencode-linux-x64-musl-1.15.5.tgz",
+      "integrity": "sha512-+RJ4AKfozICakQAOGRjaYob+uWiXI8owbsMq3KoIyHKpZsDTtQ3lvs22nVcq8cBPMJMdFbgWwHt9k9kVYBJ+jA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/opencode-windows-arm64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-arm64/-/opencode-windows-arm64-1.15.5.tgz",
+      "integrity": "sha512-uFtZyOYzV8nChWDy2IC0PnLFxj2MVfDRfJBr3CMqDnrlUS+B3DYwHkiCsbCsS/pHXpl/QbfpkAq+LSZp7mzgIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64/-/opencode-windows-x64-1.15.5.tgz",
+      "integrity": "sha512-gOtx2ap7UOJFohM1lkbkuRcXJ6MVyPX9XE5umkItAET6wcxkncqr3lcV4SqN2dU7xfqISJS6mNKEQbO7H3xyjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/opencode-windows-x64-baseline": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/opencode-windows-x64-baseline/-/opencode-windows-x64-baseline-1.15.5.tgz",
+      "integrity": "sha512-6oIoyY+ZSwsTsG2tekTZ67DKLsdRrywLECZWrJW/5Lj5aaibAc0uaQxIvNXKHbpznUU/Iaz+tgQ9D6o0OISIXg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "license": "MIT"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+      "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typebox": {
+      "version": "1.1.38",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/experiments/sdk_benchmark/package.json
+++ b/experiments/sdk_benchmark/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rhdp-rca-sdk-benchmark",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cross-SDK benchmark for the root-cause-analysis skill (Claude Agent SDK vs OpenCode vs Pi).",
+  "scripts": {
+    "smoke:opencode": "node benchmark/runners/opencode_runner.mjs < /dev/null",
+    "smoke:pi": "node benchmark/runners/pi_runner.mjs < /dev/null"
+  },
+  "dependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@opencode-ai/sdk": "*",
+    "opencode-ai": "^1.15.5"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/experiments/sdk_benchmark/package.json
+++ b/experiments/sdk_benchmark/package.json
@@ -9,8 +9,8 @@
     "smoke:pi": "node benchmark/runners/pi_runner.mjs < /dev/null"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "*",
-    "@opencode-ai/sdk": "*",
+    "@earendil-works/pi-coding-agent": "^0.75.3",
+    "@opencode-ai/sdk": "^1.15.5",
     "opencode-ai": "^1.15.5"
   },
   "engines": {

--- a/experiments/sdk_benchmark/requirements.txt
+++ b/experiments/sdk_benchmark/requirements.txt
@@ -1,0 +1,2 @@
+claude-agent-sdk>=0.1.0
+pyyaml>=6.0


### PR DESCRIPTION
## What

A runnable benchmark that drives the `root-cause-analysis` skill from three agent SDKs — **Claude Agent SDK** (Python, native), **OpenCode** and **Pi** (Node subprocess bridges) — and reports success rate, cost, duration, and turn count.

All three get the same model, the same `SKILL.md` body as system prompt, and the same tool surface, so the numbers reflect orchestration overhead rather than skill-loader differences. Everything lands under `experiments/sdk_benchmark/`; no shipped skill changes.

## How to run

```bash
cd experiments/sdk_benchmark
python3 -m venv .venv && .venv/bin/pip install -r requirements.txt && npm install

export OPENROUTER_API_KEY=sk-or-...
.venv/bin/python -m benchmark.cli run \
  --scenarios benchmark/scenarios-light.yaml \
  --skill ../../skills/root-cause-analysis \
  --provider openrouter --model anthropic/claude-sonnet-4.6 \
  --adapters claude-agent-sdk,opencode,pi
```

Reports land in `results/results-<ts>.{md,json}`. `scenarios-light.yaml` needs no infra; `scenarios.yaml` is the real RCA path (SSH + Splunk + GitHub).

## Known gaps — please read before merging

- **`pricing.py` is stale.** Opus is priced at $15/$75 (actual: $5/$25) and there are no entries for the Claude 5 models. An unknown model makes `cost_from_tokens` return `None`, which makes `scoring.over_budget` silently `False` — budget checks then pass regardless of spend. This is the fallback path only; the Claude adapter uses the SDK's native `total_cost_usd`.
- **`claude-agent-sdk>=0.1.0` is unpinned** and the SDK has since moved to 0.2.x. Needs a pin plus a re-test of the `ResultMessage` field handling.
- **`SKILL.md` is injected as a system prompt** rather than loaded natively. That was necessary when this was written; the Agent SDK now supports `setting_sources`, so the Claude side is currently handicapped relative to how we would actually ship it.
- **N=1 per cell** in every run so far — directionally interesting, not statistically meaningful.
- `bypassPermissions` on all three adapters (non-interactive benchmark); MCP servers are not wired, so the agent gets Read/Write/Edit/Bash/Grep/Glob only.

## Verification

- [x] `pytest` 61 passed, unchanged — the benchmark sits outside `testpaths`; `ruff check` + `ruff format --check` clean; no new `mypy` errors vs `main`
- [x] Rebased on `main` @ 25d62cf — conflict-free
- [ ] Fix pricing and pin the SDK before treating any output as a real cost comparison
