### PR TITLE
Batch headless script that queries unanalyzed jobs, spawns parallel C…

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -25,6 +25,7 @@
     "SOURCE_DB_PASSWORD": "<source-db-password>",
     "SOURCE_DB_TABLE": "<source-db-table>",
     "SOURCE_DB_BASTION_TABLE": "<source-db-bastion-table>",
+    "SOURCE_DB_RESULT_TABLE": "<db-results-table>",
     "SSH_JUMPBOX_ALIAS": "<ssh-jumpbox-alias>",
     "BASTION_SSH_USER": "<bastion-ssh-user>"
   },

--- a/deploy/batch-rca-automation/batch_rca_headless.sh
+++ b/deploy/batch-rca-automation/batch_rca_headless.sh
@@ -6,25 +6,25 @@ set -euo pipefail
 #############################################
 #
 # This script:
-# 1. Fetches recent failed job logs
-# 2. Filters out already-analyzed jobs
-# 3. Invokes Claude in headless mode to run parallel RCA
-# 4. Tracks analyzed jobs to prevent re-analysis
+# 1. Queries source PostgreSQL table for unanalyzed job IDs (ai_processed = FALSE)
+# 2. Invokes Claude in headless mode to run parallel RCA on those jobs
+#
+# Requires SOURCE_DB_* env vars (HOST, PORT, NAME, USER, PASSWORD, TABLE)
+# set in .claude/settings.json under "env".
 #
 # Usage:
-#   ./batch_rca_headless.sh [--limit N] [--period 5m|30m|1h|24h]
+#   ./batch_rca_headless.sh [--since 'YYYY-MM-DD HH:MM:SS'] [--limit N]
 #
-# Schedule via cron: (avoid :00, :30 load spikes)
-#   # Every 5 mins (fast testing):  3,8,13,18,23,28,33,38,43,48,53,58 * * * *
-#   # Every 30 mins (prod):         7,37 * * * *
-#   7,37 * * * * /path/to/batch_rca_headless.sh --limit 15 --period 30m >> /tmp/batch_rca.log 2>&1
+# Schedule via cron (every 30 min — each run analyzes the previous 30-min window):
+#   7,37 * * * * /path/to/batch_rca_headless.sh >> /tmp/batch_rca.log 2>&1
 #
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-STATE_FILE="$SCRIPT_DIR/analyzed_jobs.txt"
-TIMESTAMP_FILE="$SCRIPT_DIR/last_fetch_timestamp.txt"
 REPORT_DIR="$SCRIPT_DIR/reports"
+SO_SCHEMA_FILE="$SCRIPT_DIR/schemas/batch_report.structured_output.schema.json"
 TIMESTAMP=$(date -u +%Y%m%d_%H%M%S)
+BATCH_ID="batch_${TIMESTAMP}"
+REPORT_FILE="$REPORT_DIR/${BATCH_ID}.json"
 
 # Load environment variables from Claude settings.json
 SETTINGS_FILE="$SCRIPT_DIR/.claude/settings.json"
@@ -48,24 +48,26 @@ except Exception as e:
 ")"
 
 echo "[INFO] Environment variables loaded from settings.json"
-echo "  REMOTE_HOST: $REMOTE_HOST"
-echo "  REMOTE_DIR: $REMOTE_DIR"
-echo "  JOB_LOGS_DIR: $JOB_LOGS_DIR"
 
-# Default settings
-LIMIT=10
-PERIOD="30m"
+# Default: look back 30 minutes (matches the cron interval)
+SINCE=""
+LIMIT=""
+NO_PRE_FILTER=false
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
+    --since)
+      SINCE="$2"
+      shift 2
+      ;;
     --limit)
       LIMIT="$2"
       shift 2
       ;;
-    --period)
-      PERIOD="$2"
-      shift 2
+    --no-pre-filter)
+      NO_PRE_FILTER=true
+      shift
       ;;
     *)
       echo "Unknown option: $1"
@@ -74,177 +76,126 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-echo "[INFO] Batch RCA Analysis - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-echo "[INFO] Limit: $LIMIT | Period: $PERIOD"
-
-#############################################
-# Step 1: Fetch Recent Logs
-#############################################
-echo "[STEP 1] Fetching recent failed job logs..."
-
-# Calculate time window using state-based tracking to avoid overlaps
-if [ -f "$TIMESTAMP_FILE" ]; then
-  # Use last fetch timestamp as start time
-  START_TIME=$(cat "$TIMESTAMP_FILE")
-  echo "[INFO] Using last fetch time: $START_TIME"
-else
-  # First run - use period-based window
-  echo "[INFO] First run - using period-based window"
-  # Cross-platform date calculation (macOS vs Linux)
+# If --since not provided, default to 30 minutes ago
+if [ -z "$SINCE" ]; then
   if date -v-1d > /dev/null 2>&1; then
-    # macOS (BSD date)
-    case $PERIOD in
-      5m)
-        START_TIME=$(date -u -v-5M "+%Y-%m-%d %H:%M:%S")
-        ;;
-      30m)
-        START_TIME=$(date -u -v-30M "+%Y-%m-%d %H:%M:%S")
-        ;;
-      1h)
-        START_TIME=$(date -u -v-1H "+%Y-%m-%d %H:%M:%S")
-        ;;
-      24h)
-        START_TIME=$(date -u -v-24H "+%Y-%m-%d %H:%M:%S")
-        ;;
-      *)
-        echo "[ERROR] Invalid period: $PERIOD (use 5m, 30m, 1h, or 24h)"
-        exit 1
-        ;;
-    esac
+    SINCE=$(date -u -v-30M "+%Y-%m-%d %H:%M:%S")
   else
-    # Linux (GNU date)
-    case $PERIOD in
-      5m)
-        START_TIME=$(date -u -d "5 minutes ago" "+%Y-%m-%d %H:%M:%S")
-        ;;
-      30m)
-        START_TIME=$(date -u -d "30 minutes ago" "+%Y-%m-%d %H:%M:%S")
-        ;;
-      1h)
-        START_TIME=$(date -u -d "1 hour ago" "+%Y-%m-%d %H:%M:%S")
-        ;;
-      24h)
-        START_TIME=$(date -u -d "24 hours ago" "+%Y-%m-%d %H:%M:%S")
-        ;;
-      *)
-        echo "[ERROR] Invalid period: $PERIOD (use 5m, 30m, 1h, or 24h)"
-        exit 1
-        ;;
-    esac
+    SINCE=$(date -u -d "30 minutes ago" "+%Y-%m-%d %H:%M:%S")
   fi
 fi
 
-# Record current time BEFORE fetch (this becomes next run's start time)
-# Always use UTC to avoid timezone mismatches with remote server
-CURRENT_TIME=$(date -u "+%Y-%m-%d %H:%M:%S")
-echo "[INFO] Fetching logs from $START_TIME (UTC) to now"
-echo "[INFO] Local time: $(date '+%Y-%m-%d %H:%M:%S %Z')"
-
-# Fetch logs using logs-fetcher script from plugin cache
-# Assumes: REMOTE_HOST, REMOTE_DIR, JOB_LOGS_DIR are set in env
-LOGS_FETCHER_SCRIPT=$(find ~/.claude/plugins/cache -name "fetch_logs_ssh.py" 2>/dev/null | head -1)
-
-if [ -z "$LOGS_FETCHER_SCRIPT" ]; then
-  echo "[ERROR] logs-fetcher plugin not found. Please install aiops-plugin."
-  exit 1
-fi
-
-# First, get the list of files to fetch from remote (for job ID extraction)
-FILE_LIST_CMD="cd ${REMOTE_DIR} && find . -maxdepth 1 -type f -name '*.transform-processed' -newermt '${START_TIME}' -printf '%T@ %f\\n' | sort -rn | cut -d' ' -f2- | head -n ${LIMIT}"
-SSH_RAW_OUTPUT=$(ssh "$REMOTE_HOST" "$FILE_LIST_CMD" 2>&1)
-SSH_EXIT_CODE=$?
-
-if [ $SSH_EXIT_CODE -ne 0 ]; then
-  echo "[ERROR] SSH command to list files failed with exit code: $SSH_EXIT_CODE"
-  echo "[DEBUG] SSH output: $SSH_RAW_OUTPUT"
-  exit 1
-fi
-
-FILE_LIST=$(echo "$SSH_RAW_OUTPUT" | grep -v "WARNING:" | grep -v "vulnerable" | grep -v "upgraded" || true)
-
-# Now fetch the files using the logs-fetcher script
-FETCH_OUTPUT=$(python3 "$LOGS_FETCHER_SCRIPT" \
-  --mode processed \
-  --order desc \
-  --limit "$LIMIT" \
-  --start-time "$START_TIME" \
-  --local-dir "$JOB_LOGS_DIR" \
-  2>&1)
-
-FETCH_EXIT_CODE=$?
-if [ $FETCH_EXIT_CODE -ne 0 ]; then
-  echo "[ERROR] Log fetch failed with exit code: $FETCH_EXIT_CODE"
-  echo "[DEBUG] Fetch output:"
-  echo "$FETCH_OUTPUT"
-  exit 1
-fi
-
-echo "$FETCH_OUTPUT"
+echo "[INFO] Batch RCA Analysis - $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "[INFO] Analyzing events since: $SINCE"
 
 #############################################
-# Step 2: Extract Job IDs from NEWLY FETCHED files
+# Step 1: Query source DB for unanalyzed job IDs
 #############################################
-echo "[STEP 2] Extracting job IDs from newly fetched logs..."
+echo "[STEP 1] Querying source database for unanalyzed jobs..."
 
-# Extract job IDs from the file list we got from SSH
-JOB_IDS=$(echo "$FILE_LIST" | grep -E '^job_[0-9]+\.json\.gz\.transform-processed' | grep -oE 'job_[0-9]+' | sed 's/job_//' | sort -u || true)
+QUERY_ARGS=(--since "$SINCE")
+if [ -n "$LIMIT" ]; then
+  QUERY_ARGS+=(--limit "$LIMIT")
+fi
+
+JOB_IDS=$(python3 "$SCRIPT_DIR/scripts/query_source_db.py" "${QUERY_ARGS[@]}")
 
 if [ -z "$JOB_IDS" ]; then
-  echo ""
-  echo "=========================================="
-  echo "[INFO] No new jobs found in time window"
-  echo "[INFO] Time window: $START_TIME → $CURRENT_TIME (UTC)"
-  echo "[INFO] Next run will check from: $CURRENT_TIME"
-  echo "=========================================="
-  echo ""
-
-  # Update timestamp even when no jobs (prevents checking same window repeatedly)
-  echo "$CURRENT_TIME" > "$TIMESTAMP_FILE"
+  echo "[INFO] No unanalyzed jobs found"
   echo "[SUCCESS] Batch RCA completed at $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
   exit 0
 fi
 
-TOTAL_JOBS=$(echo "$JOB_IDS" | wc -l | tr -d ' ')
-echo "[INFO] Found $TOTAL_JOBS job(s): $(echo $JOB_IDS | tr '\n' ' ')"
+JOB_COUNT=$(echo "$JOB_IDS" | wc -l | tr -d ' ')
+JOBS_LIST=$(echo "$JOB_IDS" | tr '\n' ' ' | sed 's/ $//')
+echo "[INFO] Found $JOB_COUNT job(s) to analyze: $JOBS_LIST"
 
 #############################################
-# Step 3: Filter Already-Analyzed Jobs
+# Step 1b: Pre-filter against known issues
 #############################################
-echo "[STEP 3] Filtering out already-analyzed jobs..."
+PRE_MATCHED="[]"
+PRE_MATCHED_COUNT=0
+KNOWN_ISSUES="[]"
 
-# Create state file if not exists
-mkdir -p "$(dirname "$STATE_FILE")"
-touch "$STATE_FILE"
+KNOWN_ISSUES=$(python3 "$SCRIPT_DIR/scripts/fetch_known_issues.py" \
+  --lookback-hours 4 --limit 50 2>/dev/null) || KNOWN_ISSUES="[]"
 
-# Filter new jobs using comm
-NEW_JOBS=$(comm -23 \
-  <(echo "$JOB_IDS" | sort) \
-  <(sort "$STATE_FILE") \
-)
+KNOWN_COUNT=$(echo "$KNOWN_ISSUES" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))" 2>/dev/null || echo "0")
 
-if [ -z "$NEW_JOBS" ]; then
-  echo "[INFO] No new jobs to analyze (all already processed)"
-  # Update timestamp to advance cursor for next run
-  echo "$CURRENT_TIME" > "$TIMESTAMP_FILE"
-  exit 0
+if [ "$NO_PRE_FILTER" = true ]; then
+  echo "[STEP 1b] Pre-filter disabled (--no-pre-filter)"
+  echo "[INFO] $KNOWN_COUNT known issue(s) loaded for agent context"
+elif [ "$KNOWN_COUNT" = "0" ]; then
+  echo "[STEP 1b] No known issues found, skipping pre-filter"
+else
+  echo "[STEP 1b] Pre-filtering $JOB_COUNT job(s) against $KNOWN_COUNT known issue(s)..."
+
+  PRE_FILTER_OUTPUT=$(echo "$JOB_IDS" | python3 "$SCRIPT_DIR/scripts/pre_filter_jobs.py" \
+    --lookback-hours 4 2>/dev/null) || PRE_FILTER_OUTPUT=""
+
+  if [ -n "$PRE_FILTER_OUTPUT" ]; then
+    PRE_MATCHED_COUNT=$(echo "$PRE_FILTER_OUTPUT" | python3 -c "
+import json, sys
+print(len(json.load(sys.stdin).get('pre_matched', [])))
+" 2>/dev/null || echo "0")
+
+    if [ "$PRE_MATCHED_COUNT" -gt 0 ] 2>/dev/null; then
+      PRE_MATCHED=$(echo "$PRE_FILTER_OUTPUT" | python3 -c "
+import json, sys
+print(json.dumps(json.load(sys.stdin).get('pre_matched', [])))
+")
+
+      ANALYZE_IDS=$(echo "$PRE_FILTER_OUTPUT" | python3 -c "
+import json, sys
+for jid in json.load(sys.stdin).get('analyze', []):
+    print(jid)
+")
+
+      echo "[INFO] Pre-filtered: $PRE_MATCHED_COUNT job(s) matched known issues"
+
+      # Store pre-matched results immediately so they are saved regardless of
+      # whether the Claude invocation below succeeds or fails.
+      python3 "$SCRIPT_DIR/scripts/store_report.py" --pre-matched "$PRE_MATCHED" || {
+        echo "[ERROR] Failed to store pre-matched results"
+        exit 1
+      }
+
+      if [ -n "$ANALYZE_IDS" ]; then
+        JOB_IDS="$ANALYZE_IDS"
+        JOB_COUNT=$(echo "$JOB_IDS" | wc -l | tr -d ' ')
+        JOBS_LIST=$(echo "$JOB_IDS" | tr '\n' ' ' | sed 's/ $//')
+        echo "[INFO] Remaining: $JOB_COUNT job(s) for full RCA: $JOBS_LIST"
+      else
+        echo "[INFO] All jobs matched known issues, skipping Claude invocation"
+        echo "[SUCCESS] Batch RCA completed at $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+        exit 0
+      fi
+    else
+      echo "[INFO] No pre-filter matches, all $JOB_COUNT job(s) proceed to full RCA"
+    fi
+  fi
 fi
 
-NEW_COUNT=$(echo "$NEW_JOBS" | wc -l | tr -d ' ')
-echo "[INFO] Found $NEW_COUNT new job(s) to analyze: $(echo $NEW_JOBS | tr '\n' ' ')"
-
 #############################################
-# Step 4: Build Dynamic Claude Prompt
+# Step 2: Build Dynamic Claude Prompt
 #############################################
-echo "[STEP 4] Building Claude prompt for parallel RCA..."
+echo "[STEP 2] Building Claude prompt for parallel RCA..."
 
-# Convert job list to space-separated for prompt
-JOBS_LIST=$(echo "$NEW_JOBS" | tr '\n' ' ' | sed 's/ $//')
+if [ ! -f "$SO_SCHEMA_FILE" ]; then
+  echo "[ERROR] Structured output schema not found at: $SO_SCHEMA_FILE"
+  exit 1
+fi
 
 # Build the orchestration prompt
 read -r -d '' CLAUDE_PROMPT <<EOF || true
 You are running in headless mode to analyze failed jobs in parallel.
 
 **Job IDs to analyze:** $JOBS_LIST
+**Batch ID:** $BATCH_ID
+**Jobs requested:** $JOB_COUNT
+
+**Known Recent Issues (from last 4 hours):**
+$KNOWN_ISSUES
 
 **Instructions:**
 
@@ -252,39 +203,52 @@ You are running in headless mode to analyze failed jobs in parallel.
 
    Agent({
      description: "RCA for job {JOB_ID}",
-     prompt: "Invoke the 'root-cause-analysis' skill for job {JOB_ID}. Use: Skill({skill: 'root-cause-analysis', args: '{JOB_ID}'}). Follow all skill instructions including Step 5 analysis and upload. Report completion status.",
+     prompt: "Invoke the 'root-cause-analysis' skill for job {JOB_ID}. Use: Skill({skill: 'root-cause-analysis', args: '{JOB_ID}'}). Follow all skill instructions including Step 5 analysis. After Step 1 completes (job context parsing), compare failed_tasks[].error_message against the Known Recent Issues list provided in the parent prompt. If ANY error_message semantically matches a known issue's root_cause_summary (same error type, same failure mode), you may skip the remaining skill steps and report completion with the matched result_id. After completing all steps, output ONLY this JSON as your final response (no other text): {\"job_id\": \"<JOB_ID>\", \"status\": \"analyzed\", \"root_cause_category\": \"<from step5>\", \"confidence\": \"<from step5>\", \"root_cause_summary\": \"<from step5>\", \"catalog_item\": \"<from step1>\", \"platform\": \"<from step1>\", \"job_duration_seconds\": <integer from step1>, \"analysis_path\": \".analysis/<JOB_ID>/step5_analysis_summary.json\", \"recommendations\": [<top 2 high-priority recommendations from step5, each with action and details fields>]}. For early-exit match set status to matched_known_issue and add matched_result_id.",
      run_in_background: true
    })
 
    **CRITICAL:** All agents must be in ONE response for true parallelism.
+   Record agent_spawn as the ISO 8601 UTC timestamp when agents are launched.
 
 2. **Wait for completion** - You'll receive task-notification for each agent when done.
+   Record per-job duration_ms and status (completed|failed|timeout) in timing.agent_completion.
 
 3. **Aggregate results** - After all agents complete:
-   - Read each job's step5_analysis_summary.json from: ~/.claude/skills/root-cause-analysis/.analysis/{job_id}/step5_analysis_summary.json
-   - Create aggregated report with:
-     * Total jobs analyzed
-     * Root cause category breakdown (count by category)
-     * High-priority recommendations (collect top 5 from all jobs)
-     * Any failed analyses
-   - Report time taken for each step (agent spawn, wait, aggregation)
+   - Each agent emitted a compact JSON summary as its final response — extract
+     per-job data directly from the task notification text. Do NOT read any files.
+   - Tally: total_jobs_analyzed, total_jobs_failed, confidence_breakdown,
+     root_cause_category_breakdown, top-5 high_priority_recommendations
+     (deduplicated from each job's recommendations field)
+   - For any agent that reported an early-exit match against a known issue, use
+     status "matched_known_issue"; copy root_cause_category, confidence, and
+     root_cause_summary from the matched known issue
+   - **Historical matches (semantic)** — For each job with high or medium confidence,
+     compare its root_cause_summary against every entry in the Known Recent Issues list.
+     A match requires the failure to be genuinely the same: same error type, same
+     failing component, same failure mode — not just the same category label.
+     For each genuine match set historical_matches to:
+       [{"matched_result_id": <result_id>, "recurrence_count": <recurrence_count>,
+         "similarity_reasoning": "<one sentence explaining why it is the same failure>"}]
+     If no entry in the Known Recent Issues list is a genuine match, set historical_matches to [].
+   - Use batch_id: "$BATCH_ID", total_jobs_requested: $JOB_COUNT
 
-4. **Save report** - Write to: $REPORT_DIR/batch_${TIMESTAMP}.json
+4. **Cross-job patterns** - Only note genuine patterns (same failing component,
+   same error). Leave cross_job_patterns as an empty array if there is no clear
+   overlap across jobs.
 
-5. **Output completion summary** - Print to stdout:
-   - Number of jobs analyzed successfully
-   - Number of failures (if any)
-   - Report location
+5. **Write the report** - Read schemas/batch_report.structured_output.schema.json,
+   then use the Write tool to save the complete batch report as valid JSON to:
+   $REPORT_FILE
 
 **Note:** The root-cause-analysis skill handles Steps 1-5 automatically, including Claude's analysis in Step 5.
 EOF
 
 #############################################
-# Step 5: Setup MLflow
+# Step 3: Setup MLflow
 #############################################
 MLFLOW_VENV="$SCRIPT_DIR/.mlflow-venv"
 if grep -q "MLFLOW_CLAUDE_TRACING_ENABLED.*true" "$SETTINGS_FILE" 2>/dev/null; then
-  echo "[STEP 5] Setting up MLflow tracing..."
+  echo "[STEP 3] Setting up MLflow tracing..."
 
   if [ ! -d "$MLFLOW_VENV" ]; then
     echo "[INFO] Creating MLflow venv (first run)..."
@@ -295,42 +259,49 @@ if grep -q "MLFLOW_CLAUDE_TRACING_ENABLED.*true" "$SETTINGS_FILE" 2>/dev/null; t
 
   echo "[INFO] MLflow tracing enabled"
 else
-  echo "[STEP 5] MLflow tracing disabled (skipping)"
+  echo "[STEP 3] MLflow tracing disabled (skipping)"
 fi
 
 #############################################
-# Step 6: Execute Claude Headless
+# Step 4: Execute Claude Headless
 #############################################
-echo "[STEP 6] Executing Claude in headless mode..."
+echo "[STEP 4] Executing Claude in headless mode..."
 
 mkdir -p "$REPORT_DIR"
-
-# Run claude in non-interactive mode with permissions bypass for testing
-# Note: -p/--print flag for non-interactive output
-# Using --dangerously-skip-permissions for testing only
-# Run from script directory to pick up .claude/settings.json
 cd "$SCRIPT_DIR" || exit 1
 
-claude -p --dangerously-skip-permissions "$CLAUDE_PROMPT" || {
+CLAUDE_STDERR_FILE=$(mktemp)
+claude -p \
+  --allowedTools "Agent,Bash,Read,Write,mcp__github__search_code,mcp__github__get_file_contents" \
+  --model claude-sonnet-4-6 \
+  "$CLAUDE_PROMPT" 2>"$CLAUDE_STDERR_FILE" || {
   echo "[ERROR] Claude execution failed"
+  echo "[DEBUG] stderr: $(cat "$CLAUDE_STDERR_FILE")"
+  rm -f "$CLAUDE_STDERR_FILE"
+  exit 1
+}
+rm -f "$CLAUDE_STDERR_FILE"
+
+#############################################
+# Step 4b: Verify report was written
+#############################################
+echo "[STEP 4b] Verifying report..."
+
+if [ ! -f "$REPORT_FILE" ]; then
+  echo "[ERROR] Claude did not write report to $REPORT_FILE"
+  exit 1
+fi
+echo "[INFO] Report written to $REPORT_FILE"
+
+#############################################
+# Step 5: Store report in local DB
+#############################################
+echo "[STEP 5] Storing report in local database..."
+
+python3 "$SCRIPT_DIR/scripts/store_report.py" "$REPORT_FILE" || {
+  echo "[ERROR] Failed to store report in database"
   exit 1
 }
 
-#############################################
-# Step 7: Update State
-#############################################
-echo "[STEP 7] Updating analyzed jobs state..."
-
-# Append new jobs to state file
-echo "$NEW_JOBS" >> "$STATE_FILE"
-
-# Keep state file sorted and deduplicated
-sort -u "$STATE_FILE" -o "$STATE_FILE"
-
-# Save timestamp ONLY AFTER successful analysis (prevents lost jobs on failure)
-echo "$CURRENT_TIME" > "$TIMESTAMP_FILE"
-echo "[INFO] Saved timestamp for next run: $CURRENT_TIME"
-
 echo "[SUCCESS] Batch RCA completed at $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-echo "[INFO] Report: $REPORT_DIR/batch_${TIMESTAMP}.json"
-echo "[INFO] Analyzed jobs added to: $STATE_FILE"
+echo "[INFO] Report: $REPORT_FILE"

--- a/deploy/batch-rca-automation/requirements.txt
+++ b/deploy/batch-rca-automation/requirements.txt
@@ -1,0 +1,2 @@
+psycopg2-binary>=2.9
+python-dotenv>=1.0

--- a/deploy/batch-rca-automation/schemas/batch_report.structured_output.schema.json
+++ b/deploy/batch-rca-automation/schemas/batch_report.structured_output.schema.json
@@ -1,0 +1,153 @@
+{
+  "type": "object",
+  "required": [
+    "batch_id",
+    "generated_at",
+    "total_jobs_requested",
+    "total_jobs_analyzed",
+    "total_jobs_failed",
+    "timing",
+    "root_cause_category_breakdown",
+    "confidence_breakdown",
+    "high_priority_recommendations",
+    "job_summaries",
+    "failed_analyses",
+    "cross_job_patterns"
+  ],
+  "properties": {
+    "batch_id": { "type": "string" },
+    "generated_at": { "type": "string" },
+    "total_jobs_requested": { "type": "integer", "minimum": 0 },
+    "total_jobs_analyzed": { "type": "integer", "minimum": 0 },
+    "total_jobs_failed": { "type": "integer", "minimum": 0 },
+    "timing": {
+      "type": "object",
+      "required": ["agent_spawn", "agent_completion", "wall_clock_total_ms", "aggregation_completed_at"],
+      "properties": {
+        "agent_spawn": { "type": "string" },
+        "agent_completion": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["duration_ms", "status"],
+            "properties": {
+              "duration_ms": { "type": "integer", "minimum": 0 },
+              "status": { "type": "string", "enum": ["completed", "failed", "timeout"] }
+            }
+          }
+        },
+        "wall_clock_total_ms": { "type": "integer", "minimum": 0 },
+        "aggregation_completed_at": { "type": "string" }
+      }
+    },
+    "root_cause_category_breakdown": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "required": ["count", "job_ids", "description"],
+        "properties": {
+          "count": { "type": "integer", "minimum": 1 },
+          "job_ids": { "type": "array", "items": { "type": "string" } },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "confidence_breakdown": {
+      "type": "object",
+      "required": ["high", "medium", "low"],
+      "properties": {
+        "high": { "type": "integer", "minimum": 0 },
+        "medium": { "type": "integer", "minimum": 0 },
+        "low": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "high_priority_recommendations": {
+      "type": "array",
+      "maxItems": 5,
+      "items": {
+        "type": "object",
+        "required": ["rank", "priority", "action", "affects_jobs", "category", "details"],
+        "properties": {
+          "rank": { "type": "integer", "minimum": 1, "maximum": 5 },
+          "priority": { "type": "string", "enum": ["high", "medium", "low"] },
+          "action": { "type": "string" },
+          "affects_jobs": { "type": "array", "items": { "type": "string" } },
+          "category": {
+            "type": "string",
+            "enum": ["application_bug", "infrastructure", "configuration", "dependency", "network", "resource", "cloud_api", "secrets", "unknown"]
+          },
+          "details": { "type": "string" },
+          "github_path": { "type": "string" }
+        }
+      }
+    },
+    "job_summaries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["job_id", "status"],
+        "properties": {
+          "job_id": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["analyzed", "failed", "matched_known_issue"]
+          },
+          "root_cause_category": {
+            "type": "string",
+            "enum": ["application_bug", "infrastructure", "configuration", "dependency", "network", "resource", "cloud_api", "secrets", "unknown"]
+          },
+          "confidence": { "type": "string", "enum": ["high", "medium", "low"] },
+          "root_cause_summary": { "type": "string" },
+          "catalog_item": { "type": "string" },
+          "platform": { "type": "string" },
+          "job_duration_seconds": { "type": "integer", "minimum": 0 },
+          "analysis_duration_ms": { "type": "integer", "minimum": 0 },
+          "failing_role": { "type": "string" },
+          "failing_github_path": { "type": "string" },
+          "analysis_path": { "type": "string" },
+          "historical_matches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["matched_result_id", "recurrence_count", "similarity_reasoning"],
+              "properties": {
+                "matched_result_id": { "type": "integer" },
+                "recurrence_count": { "type": "integer", "minimum": 1 },
+                "similarity_reasoning": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "failed_analyses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["job_id", "error"],
+        "properties": {
+          "job_id": { "type": "string" },
+          "error": { "type": "string" },
+          "stage": {
+            "type": "string",
+            "enum": ["agent_spawn", "skill_execution", "step5_missing", "upload"]
+          }
+        }
+      }
+    },
+    "cross_job_patterns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["pattern", "jobs", "description", "source"],
+        "properties": {
+          "pattern": { "type": "string" },
+          "jobs": { "type": "array", "items": { "type": "string" } },
+          "description": { "type": "string" },
+          "source": { "type": "string", "enum": ["current_batch", "historical"] },
+          "shared_github_path": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/deploy/batch-rca-automation/scripts/fetch_known_issues.py
+++ b/deploy/batch-rca-automation/scripts/fetch_known_issues.py
@@ -1,0 +1,91 @@
+"""Fetch recent high-confidence results from aap2_job_results for agent context."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg2
+import psycopg2.sql
+from utils import connect_db, load_config
+
+
+def fetch_known_issues(
+    conn: Any, results_table: str, lookback_hours: int = 4, limit: int = 50
+) -> list[dict[str, Any]]:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback_hours)
+    cutoff_batch_id = f"batch_{cutoff.strftime('%Y%m%d_%H%M%S')}"
+
+    with conn.cursor() as cur:
+        cur.execute(
+            psycopg2.sql.SQL(
+                """SELECT * FROM (
+                       SELECT DISTINCT ON (root_cause_category, catalog_item)
+                              id, catalog_item, root_cause_category, root_cause_summary,
+                              batch_id, confidence,
+                              COUNT(*) OVER (
+                                  PARTITION BY root_cause_category, catalog_item
+                              ) AS recurrence_count
+                       FROM {}
+                       WHERE confidence = 'high'
+                         AND batch_id >= %s
+                         AND status = 'analyzed'
+                       ORDER BY root_cause_category, catalog_item, batch_id DESC
+                   ) sub
+                   ORDER BY batch_id DESC
+                   LIMIT %s"""
+            ).format(psycopg2.sql.Identifier(results_table)),
+            (cutoff_batch_id, limit),
+        )
+        rows = cur.fetchall()
+
+    return [
+        {
+            "result_id": row["id"],
+            "catalog_item": row["catalog_item"],
+            "root_cause_category": row["root_cause_category"],
+            "root_cause_summary": row["root_cause_summary"],
+            "batch_id": row["batch_id"],
+            "confidence": row["confidence"],
+            "recurrence_count": row["recurrence_count"],
+        }
+        for row in rows
+    ]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fetch recent known issues from results table")
+    parser.add_argument(
+        "--lookback-hours", type=int, default=4, help="How far back to look (default: 4)"
+    )
+    parser.add_argument("--limit", type=int, default=50, help="Max results to return (default: 50)")
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(required=("name", "user", "password", "results_table"))
+    except SystemExit:
+        return 1
+
+    try:
+        conn = connect_db(config, use_dict_cursor=True)
+    except psycopg2.OperationalError as e:
+        print(f"Cannot connect to database: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        issues = fetch_known_issues(conn, config["results_table"], args.lookback_hours, args.limit)
+    except psycopg2.Error as e:
+        print(f"Query failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    print(json.dumps(issues, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/batch-rca-automation/scripts/pre_filter_jobs.py
+++ b/deploy/batch-rca-automation/scripts/pre_filter_jobs.py
@@ -1,0 +1,227 @@
+"""Pre-filter jobs against recent known results before spawning Claude agents.
+
+Matches on catalog_item + error_message similarity. A job is only pre-matched when:
+  1. Its catalog_item matches a recent high-confidence result unambiguously
+     (only one distinct root_cause_category for that catalog_item in the window)
+  2. Its error_message is similar enough to the original job's error_message
+     (SequenceMatcher ratio >= MATCH_THRESHOLD)
+
+If either side is missing an error_message the job proceeds to full RCA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg2
+import psycopg2.sql
+from utils import connect_db, load_config
+
+MATCH_THRESHOLD = 0.75
+
+
+def extract_catalog_item(job_name: str) -> str | None:
+    """Extract catalog_item from job_name.
+
+    Handles the RHPDS format: 'RHPDS {platform}.{catalog_item}.{env}-{guid}-{action} ...'
+    """
+    name = job_name.removeprefix("RHPDS ").strip()
+    if " " in name:
+        name = name.split(maxsplit=1)[0]
+    parts = name.split(".")
+    if len(parts) >= 3:
+        return ".".join(parts[1:-1])
+    if len(parts) == 2:
+        return parts[1].split("-")[0] if "-" in parts[1] else parts[1]
+    return None
+
+
+_MAX_CMP_LEN = 5000
+
+
+def error_similarity(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, a[:_MAX_CMP_LEN], b[:_MAX_CMP_LEN]).ratio()
+
+
+def fetch_filter_context(
+    conn: Any,
+    results_table: str,
+    source_table: str,
+    job_ids: list[int],
+    lookback_hours: int = 4,
+) -> tuple[list[dict[str, Any]], dict[int, dict[str, Any]]]:
+    """Fetch recent known results and incoming job metadata in one pass.
+
+    Returns (recent_results, job_metadata) where:
+      - recent_results: high-confidence analyzed results with error_message from the source table
+      - job_metadata: {job_id: {job_name, error_message}} for the incoming jobs
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback_hours)
+    cutoff_batch_id = f"batch_{cutoff.strftime('%Y%m%d_%H%M%S')}"
+
+    with conn.cursor() as cur:
+        cur.execute(
+            psycopg2.sql.SQL(
+                """SELECT r.id, r.catalog_item, r.root_cause_category,
+                          r.root_cause_summary, e.error_message
+                   FROM {results} r
+                   LEFT JOIN {source} e ON r.job_id::text = e.job_id::text
+                   WHERE r.confidence = 'high'
+                     AND r.batch_id >= %s
+                     AND r.status = 'analyzed'
+                   ORDER BY r.batch_id DESC"""
+            ).format(
+                results=psycopg2.sql.Identifier(results_table),
+                source=psycopg2.sql.Identifier(source_table),
+            ),
+            (cutoff_batch_id,),
+        )
+        recent_results = [dict(row) for row in cur.fetchall()]
+
+        cur.execute(
+            psycopg2.sql.SQL(
+                """SELECT job_id, job_name, error_message
+                   FROM {} WHERE job_id = ANY(%s) AND job_finished >= %s"""
+            ).format(psycopg2.sql.Identifier(source_table)),
+            (job_ids, cutoff),
+        )
+        job_metadata = {
+            row["job_id"]: {
+                "job_name": row["job_name"],
+                "error_message": row["error_message"],
+            }
+            for row in cur.fetchall()
+            if row["job_name"]
+        }
+
+    return recent_results, job_metadata
+
+
+def build_catalog_index(recent_results: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build catalog_item -> result index, excluding ambiguous items.
+
+    A catalog_item is excluded when it has more than one distinct root_cause_category
+    in the lookback window — the same item is failing for different reasons so we
+    cannot safely pre-match new jobs against it.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for result in recent_results:
+        ci = result["catalog_item"]
+        if not ci:
+            continue
+        grouped.setdefault(ci, []).append(result)
+
+    return {
+        ci: results[0]  # most recent (results ordered by batch_id DESC)
+        for ci, results in grouped.items()
+        if len({r["root_cause_category"] for r in results}) == 1
+    }
+
+
+def pre_filter(
+    job_metadata: dict[int, dict[str, Any]],
+    catalog_index: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    analyze = []
+    pre_matched = []
+
+    for job_id, meta in job_metadata.items():
+        extracted = extract_catalog_item(meta["job_name"])
+        matched_result = catalog_index.get(extracted) if extracted else None
+
+        if matched_result:
+            new_err = meta.get("error_message") or ""
+            known_err = matched_result.get("error_message") or ""
+
+            if not new_err or not known_err:
+                matched_result = None  # can't compare — send to full RCA
+            elif error_similarity(new_err, known_err) < MATCH_THRESHOLD:
+                matched_result = None  # different error — send to full RCA
+
+        if matched_result:
+            pre_matched.append(
+                {
+                    "job_id": job_id,
+                    "matched_result_id": matched_result["id"],
+                    "catalog_item": matched_result["catalog_item"],
+                    "root_cause_category": matched_result["root_cause_category"],
+                    "match_reason": "pre_filter_catalog_item+error_message",
+                    "recent_result_summary": matched_result["root_cause_summary"][:200],
+                }
+            )
+        else:
+            analyze.append(job_id)
+
+    return {"analyze": analyze, "pre_matched": pre_matched}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Pre-filter jobs against known results")
+    parser.add_argument(
+        "--input",
+        type=str,
+        default=None,
+        help="File with newline-separated job IDs (default: stdin)",
+    )
+    parser.add_argument(
+        "--lookback-hours", type=int, default=4, help="Lookback window (default: 4)"
+    )
+    args = parser.parse_args(argv)
+
+    if args.input:
+        with open(args.input) as f:
+            raw = f.read()
+    else:
+        raw = sys.stdin.read()
+
+    job_ids = [int(line.strip()) for line in raw.strip().splitlines() if line.strip()]
+    if not job_ids:
+        print(json.dumps({"analyze": [], "pre_matched": []}))
+        return 0
+
+    try:
+        config = load_config(required=("name", "user", "password", "source_table", "results_table"))
+    except SystemExit:
+        return 1
+
+    try:
+        conn = connect_db(config, use_dict_cursor=True)
+    except psycopg2.OperationalError as e:
+        print(f"Cannot connect to database: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        recent_results, job_metadata = fetch_filter_context(
+            conn,
+            config["results_table"],
+            config["source_table"],
+            job_ids,
+            args.lookback_hours,
+        )
+        if not recent_results:
+            print(json.dumps({"analyze": job_ids, "pre_matched": []}))
+            return 0
+
+        catalog_index = build_catalog_index(recent_results)
+
+        unknown_ids = [jid for jid in job_ids if jid not in job_metadata]
+        result = pre_filter(job_metadata, catalog_index)
+        result["analyze"].extend(unknown_ids)
+
+    except psycopg2.Error as e:
+        print(f"Query failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/batch-rca-automation/scripts/query_historical_matches.py
+++ b/deploy/batch-rca-automation/scripts/query_historical_matches.py
@@ -1,0 +1,280 @@
+"""Query historical results narrowly filtered by (root_cause_category, catalog_item) pairs."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import sys
+import tempfile
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg2
+import psycopg2.sql
+from utils import connect_db, load_config
+
+
+def query_matches(
+    conn: Any,
+    table: str,
+    pairs: list[dict[str, str]],
+    exclude_batch: str | None = None,
+    lookback_days: int = 7,
+    limit_per_group: int = 10,
+) -> list[dict]:
+    if not pairs:
+        return []
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=lookback_days)
+    cutoff_batch_id = f"batch_{cutoff.strftime('%Y%m%d_%H%M%S')}"
+
+    tuple_values = []
+    for p in pairs:
+        tuple_values.extend([p["root_cause_category"], p["catalog_item"]])
+
+    in_clause = ", ".join(["(%s, %s)"] * len(pairs))
+
+    query = psycopg2.sql.SQL(
+        "SELECT id, job_id, batch_id, root_cause_category, root_cause_summary,"
+        " confidence, catalog_item"
+        " FROM {}"
+        " WHERE batch_id >= %s"
+        " AND (root_cause_category, catalog_item) IN (" + in_clause + ")"
+        " AND confidence IN ('high', 'medium')"
+        " AND status = 'analyzed'"
+        " ORDER BY batch_id DESC"
+    ).format(psycopg2.sql.Identifier(table))
+
+    params: list[Any] = [cutoff_batch_id]
+    if exclude_batch:
+        query = psycopg2.sql.SQL(
+            "SELECT id, job_id, batch_id, root_cause_category, root_cause_summary,"
+            " confidence, catalog_item"
+            " FROM {}"
+            " WHERE batch_id >= %s AND batch_id != %s"
+            " AND (root_cause_category, catalog_item) IN (" + in_clause + ")"
+            " AND confidence IN ('high', 'medium')"
+            " AND status = 'analyzed'"
+            " ORDER BY batch_id DESC"
+        ).format(psycopg2.sql.Identifier(table))
+        params = [cutoff_batch_id, exclude_batch]
+
+    params.extend(tuple_values)
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        rows = cur.fetchall()
+
+    if not rows:
+        return []
+
+    groups: dict[tuple, dict] = {}
+    for row in rows:
+        key = (row["root_cause_category"], row["catalog_item"])
+        if key not in groups:
+            groups[key] = {
+                "root_cause_category": row["root_cause_category"],
+                "catalog_item": row["catalog_item"],
+                "occurrence_count": 0,
+                "results": [],
+            }
+        if groups[key]["occurrence_count"] < limit_per_group:
+            groups[key]["results"].append(
+                {
+                    "id": row["id"],
+                    "job_id": row["job_id"],
+                    "batch_id": row["batch_id"],
+                    "root_cause_summary": row["root_cause_summary"],
+                    "confidence": row["confidence"],
+                }
+            )
+        groups[key]["occurrence_count"] += 1
+
+    return sorted(groups.values(), key=lambda g: g["occurrence_count"], reverse=True)
+
+
+def _extract_pairs(report: dict) -> list[dict[str, str]]:
+    """Extract unique high-confidence (root_cause_category, catalog_item) pairs from a batch report."""
+    seen: set[tuple[str, str]] = set()
+    pairs = []
+    for job in report.get("job_summaries", []):
+        cat = job.get("root_cause_category")
+        ci = job.get("catalog_item")
+        conf = job.get("confidence")
+        if conf == "high" and cat and ci:
+            key = (cat, ci)
+            if key not in seen:
+                pairs.append({"root_cause_category": cat, "catalog_item": ci})
+                seen.add(key)
+    return pairs
+
+
+_SIMILARITY_THRESHOLD = 0.6
+
+
+def merge_historical_into_report(
+    report: dict,
+    groups: list[dict],
+    max_matches: int = 3,
+) -> dict:
+    """Attach historical_matches to each high-confidence job_summary in the report."""
+    group_map = {(g["root_cause_category"], g["catalog_item"]): g for g in groups}
+    for job in report.get("job_summaries", []):
+        if job.get("confidence") != "high":
+            continue
+        key = (job.get("root_cause_category"), job.get("catalog_item"))
+        group = group_map.get(key)
+        if group:
+            job_summary = job.get("root_cause_summary", "")
+            similar = [
+                r
+                for r in group["results"]
+                if difflib.SequenceMatcher(
+                    None, job_summary, r.get("root_cause_summary", "")
+                ).ratio()
+                >= _SIMILARITY_THRESHOLD
+            ]
+            job["historical_matches"] = [
+                {
+                    "matched_result_id": r["id"],
+                    "recurrence_count": group["occurrence_count"],
+                    "similarity_reasoning": (
+                        f"Same {key[0]} failure in {key[1]} "
+                        f"({group['occurrence_count']} prior occurrence(s))"
+                    ),
+                }
+                for r in similar[:max_matches]
+            ]
+        else:
+            job["historical_matches"] = []
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Query historical results filtered by (root_cause_category, catalog_item) pairs"
+    )
+    parser.add_argument(
+        "--input",
+        metavar="FILE",
+        help="JSON file with pairs to query (reads stdin if omitted)",
+    )
+    parser.add_argument(
+        "--report",
+        metavar="FILE",
+        help="Batch report JSON to annotate with historical_matches (alternative to --input)",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        help="Write annotated report to this path (used with --report; defaults to overwrite input)",
+    )
+    parser.add_argument(
+        "--exclude-batch",
+        metavar="BATCH_ID",
+        help="Exclude this batch_id from results (avoid self-matching)",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=7,
+        help="Days to look back (default: 7)",
+    )
+    parser.add_argument(
+        "--limit-per-group",
+        type=int,
+        default=10,
+        help="Max results per (category, catalog_item) group (default: 10)",
+    )
+    args = parser.parse_args(argv)
+
+    # --report mode: read report, extract pairs, merge matches back in
+    if args.report:
+        try:
+            with open(args.report) as f:
+                report = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Failed to read report: {e}", file=sys.stderr)
+            return 1
+
+        pairs = _extract_pairs(report)
+        if not pairs:
+            print("No high-confidence job summaries found; nothing to correlate.", file=sys.stderr)
+            return 0
+
+        try:
+            config = load_config(required=("name", "user", "password", "results_table"))
+            conn = connect_db(config, use_dict_cursor=True)
+        except (SystemExit, psycopg2.OperationalError) as e:
+            print(f"DB connection failed: {e}", file=sys.stderr)
+            return 1
+
+        groups = query_matches(
+            conn,
+            config["results_table"],
+            pairs,
+            exclude_batch=args.exclude_batch,
+            lookback_days=args.lookback_days,
+            limit_per_group=args.limit_per_group,
+        )
+        conn.close()
+
+        updated = merge_historical_into_report(report, groups)
+        out_path = args.output or args.report
+        out_dir = os.path.dirname(os.path.abspath(out_path))
+        fd, tmp_path = tempfile.mkstemp(dir=out_dir, suffix=".json")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(updated, f, indent=2)
+            os.replace(tmp_path, out_path)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
+        print(f"Historical matches written to {out_path}", file=sys.stderr)
+        return 0
+
+    # --input / stdin mode: return raw groups as JSON
+    try:
+        if args.input:
+            with open(args.input) as f:
+                pairs = json.load(f)
+        else:
+            pairs = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"Failed to read pairs input: {e}", file=sys.stderr)
+        return 1
+
+    if not isinstance(pairs, list) or not pairs:
+        json.dump([], sys.stdout)
+        print()
+        return 0
+
+    try:
+        config = load_config(required=("name", "user", "password", "results_table"))
+    except SystemExit:
+        return 1
+
+    try:
+        conn = connect_db(config, use_dict_cursor=True)
+    except psycopg2.OperationalError as e:
+        print(f"Cannot connect to database: {e}", file=sys.stderr)
+        return 1
+
+    result = query_matches(
+        conn,
+        config["results_table"],
+        pairs,
+        exclude_batch=args.exclude_batch,
+        lookback_days=args.lookback_days,
+        limit_per_group=args.limit_per_group,
+    )
+    conn.close()
+    json.dump(result, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/batch-rca-automation/scripts/query_source_db.py
+++ b/deploy/batch-rca-automation/scripts/query_source_db.py
@@ -1,0 +1,97 @@
+"""Query source PostgreSQL table for unanalyzed job IDs.
+
+Reads events where ai_processed = FALSE and outputs distinct job IDs,
+one per line. The batch script passes these to Claude agents for RCA.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+import psycopg2
+import psycopg2.sql
+from utils import connect_db, load_config
+
+
+def query_job_ids(
+    conn: Any, table: str, since: str | None = None, limit: int | None = None
+) -> list[int]:
+    conditions = ["(ai_processed IS NULL OR ai_processed = FALSE)"]
+    params: list[Any] = []
+
+    if since:
+        conditions.append("job_started >= %s")
+        params.append(since)
+
+    suffix = ""
+    if limit is not None:
+        suffix = " LIMIT %s"
+        params.append(limit)
+
+    query = psycopg2.sql.SQL(
+        "SELECT DISTINCT job_id "
+        "FROM {} "
+        "WHERE " + " AND ".join(conditions) + " "
+        "ORDER BY job_id DESC" + suffix
+    ).format(psycopg2.sql.Identifier(table))
+
+    with conn.cursor() as cur:
+        cur.execute(query, params)
+        return [row["job_id"] for row in cur.fetchall()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Query source DB for unanalyzed job IDs")
+    parser.add_argument(
+        "--since",
+        type=str,
+        default=None,
+        help="Only include events after this timestamp (e.g. '2024-06-01 08:00:00')",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Maximum number of job IDs to return"
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Save job IDs to this file (default: print to stdout)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(required=("name", "user", "password", "source_table"))
+    except SystemExit:
+        return 1
+
+    conn = None
+    try:
+        conn = connect_db(config, use_dict_cursor=True)
+        job_ids = query_job_ids(conn, config["source_table"], args.since, args.limit)
+    except psycopg2.OperationalError as e:
+        print(f"Cannot connect to source database: {e}", file=sys.stderr)
+        return 1
+    except psycopg2.Error as e:
+        print(f"Query failed: {e}", file=sys.stderr)
+        return 1
+    finally:
+        if conn:
+            conn.close()
+
+    output = "\n".join(str(jid) for jid in job_ids)
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(output + "\n" if output else "")
+        print(f"Saved {len(job_ids)} job ID(s) to {args.output}", file=sys.stderr)
+    else:
+        if output:
+            print(output)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/batch-rca-automation/scripts/store_report.py
+++ b/deploy/batch-rca-automation/scripts/store_report.py
@@ -1,0 +1,267 @@
+"""Store batch RCA JSON reports into a results table on the source database."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import glob
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import psycopg2
+import psycopg2.sql
+from utils import connect_db, load_config
+
+MATCH_THRESHOLD = 0.85
+LOOKBACK_HOURS = 4
+
+
+def find_match(cur: Any, results_table: str, job: dict[str, Any]) -> int | None:
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=LOOKBACK_HOURS)
+    cutoff_batch_id = f"batch_{cutoff.strftime('%Y%m%d_%H%M%S')}"
+
+    cur.execute(
+        psycopg2.sql.SQL(
+            """SELECT id, root_cause_summary FROM {}
+               WHERE root_cause_category = %s AND catalog_item = %s
+                 AND confidence = 'high' AND batch_id >= %s"""
+        ).format(psycopg2.sql.Identifier(results_table)),
+        (job.get("root_cause_category"), job.get("catalog_item"), cutoff_batch_id),
+    )
+    summary = job.get("root_cause_summary", "")
+    for row_id, existing_summary in cur.fetchall():
+        ratio = difflib.SequenceMatcher(None, summary, existing_summary).ratio()
+        if ratio >= MATCH_THRESHOLD:
+            print(f"[MATCH] job {job.get('job_id')} ({ratio:.0%}) -> result {row_id}")
+            print(f"  Current:    {summary[:120]}")
+            print(f"  Historical: {existing_summary[:120]}")
+            return row_id
+    return None
+
+
+def _validate_match_id(cur: Any, results_table: str, matched_id: int, job: dict[str, Any]) -> bool:
+    cur.execute(
+        psycopg2.sql.SQL(
+            """SELECT 1 FROM {}
+               WHERE id = %s AND root_cause_category = %s
+                 AND catalog_item = %s AND confidence = 'high'"""
+        ).format(psycopg2.sql.Identifier(results_table)),
+        (matched_id, job.get("root_cause_category"), job.get("catalog_item")),
+    )
+    return cur.fetchone() is not None
+
+
+def store_report(
+    conn: Any, config: dict[str, Any], report: dict[str, Any], filename: str | None = None
+) -> bool:
+    batch_id = report.get("batch_id")
+    if not batch_id and filename:
+        base = os.path.splitext(os.path.basename(filename))[0]
+        batch_id = base
+    if not batch_id:
+        print("[ERROR] Cannot determine batch_id", file=sys.stderr)
+        return False
+
+    results_table = config["results_table"]
+    source_table = config["source_table"]
+
+    jobs = report.get("job_results") or report.get("job_summaries") or report.get("jobs", [])
+    with conn.cursor() as cur:
+        for job in jobs:
+            jid = str(job.get("job_id", ""))
+            status = job.get("status")
+
+            matched_id = None
+            if status in ("analyzed", "matched_known_issue"):
+                candidate_id = job.get("matched_result_id")
+                if candidate_id is None:
+                    hist = job.get("historical_matches")
+                    if hist and isinstance(hist, list) and len(hist) > 0:
+                        candidate_id = hist[0].get("matched_result_id")
+
+                if candidate_id is not None:
+                    if _validate_match_id(cur, results_table, candidate_id, job):
+                        matched_id = candidate_id
+                        print(f"[MATCH-AGENT] job {jid} -> result {matched_id} (validated)")
+                    else:
+                        print(f"[WARN] job {jid}: declared match {candidate_id} failed validation")
+
+                if matched_id is None:
+                    matched_id = find_match(cur, results_table, job)
+
+            if matched_id is not None:
+                cur.execute(
+                    psycopg2.sql.SQL(
+                        """UPDATE {} SET aap2_job_results_fk_id = %s, ai_processed = TRUE
+                           WHERE job_id = %s"""
+                    ).format(psycopg2.sql.Identifier(source_table)),
+                    (matched_id, jid),
+                )
+            else:
+                cur.execute(
+                    psycopg2.sql.SQL(
+                        """INSERT INTO {}
+                           (batch_id, job_id, status, root_cause_category, root_cause_summary,
+                            confidence, catalog_item, job_duration_seconds, ticket_link, is_open)
+                           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                           ON CONFLICT (batch_id, job_id) DO UPDATE SET status = EXCLUDED.status
+                           RETURNING id"""
+                    ).format(psycopg2.sql.Identifier(results_table)),
+                    (
+                        batch_id,
+                        jid,
+                        job.get("status"),
+                        job.get("root_cause_category"),
+                        job.get("root_cause_summary"),
+                        job.get("confidence"),
+                        job.get("catalog_item"),
+                        job.get("job_duration_seconds"),
+                        job.get("ticket_link"),
+                        job.get("is_open", False),
+                    ),
+                )
+                row = cur.fetchone()
+                new_id = row[0] if row else None
+
+                if status in ("analyzed", "matched_known_issue"):
+                    cur.execute(
+                        psycopg2.sql.SQL(
+                            """UPDATE {} SET aap2_job_results_fk_id = %s, ai_processed = TRUE
+                               WHERE job_id = %s"""
+                        ).format(psycopg2.sql.Identifier(source_table)),
+                        (new_id, jid),
+                    )
+
+    conn.commit()
+    return True
+
+
+def store_pre_matched(conn: Any, config: dict[str, Any], pre_matched: list[dict[str, Any]]) -> int:
+    """Store pre-filtered jobs that were matched before Claude invocation."""
+    source_table = config["source_table"]
+    count = 0
+    with conn.cursor() as cur:
+        for job in pre_matched:
+            jid = str(job["job_id"])
+            matched_id = job["matched_result_id"]
+            cur.execute(
+                psycopg2.sql.SQL(
+                    """UPDATE {} SET aap2_job_results_fk_id = %s, ai_processed = TRUE
+                       WHERE job_id = %s"""
+                ).format(psycopg2.sql.Identifier(source_table)),
+                (matched_id, jid),
+            )
+            print(
+                f"[PRE-MATCH] job {jid} -> result {matched_id}"
+                f" (reason: {job.get('match_reason', 'catalog_item')})"
+            )
+            count += 1
+    conn.commit()
+    return count
+
+
+def store_cross_patterns(conn: Any, config: dict[str, Any], report: dict[str, Any]) -> None:
+    patterns = report.get("cross_job_patterns", [])
+    if not patterns:
+        return
+    results_table = config["results_table"]
+    batch_id = report.get("batch_id", "")
+    with conn.cursor() as cur:
+        for p in patterns:
+            pattern_name = p.get("pattern")
+            description = p.get("description")
+            for job_id in p.get("jobs", []):
+                cur.execute(
+                    psycopg2.sql.SQL(
+                        """UPDATE {}
+                           SET cross_job_pattern = %s, cross_job_pattern_description = %s
+                           WHERE batch_id = %s AND job_id = %s"""
+                    ).format(psycopg2.sql.Identifier(results_table)),
+                    (pattern_name, description, batch_id, str(job_id)),
+                )
+    conn.commit()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Store batch RCA reports in PostgreSQL")
+    parser.add_argument("report", nargs="?", help="Path to a batch report JSON file")
+    parser.add_argument("--backfill", metavar="DIR", help="Load all batch_*.json files from DIR")
+    parser.add_argument(
+        "--pre-matched",
+        metavar="JSON",
+        help="JSON array of pre-matched jobs from pre_filter_jobs.py (stdin if '-')",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.report and not args.backfill and not args.pre_matched:
+        parser.error("Provide a report path, --backfill DIR, or --pre-matched JSON")
+
+    try:
+        config = load_config(required=("name", "user", "password", "results_table", "source_table"))
+    except SystemExit:
+        return 1
+
+    try:
+        conn = connect_db(config)
+    except psycopg2.OperationalError as e:
+        print(f"Cannot connect to database: {e}", file=sys.stderr)
+        return 1
+
+    print(f"[INFO] Connected as user: {config['user']} on {config['results_table']}")
+
+    if args.pre_matched:
+        try:
+            if args.pre_matched == "-":
+                pre_matched = json.load(sys.stdin)
+            else:
+                pre_matched = json.loads(args.pre_matched)
+            count = store_pre_matched(conn, config, pre_matched)
+            print(f"[DONE] {count} pre-matched job(s) stored")
+        except (json.JSONDecodeError, KeyError) as e:
+            print(f"[ERROR] Invalid pre-matched JSON: {e}", file=sys.stderr)
+            return 1
+        finally:
+            conn.close()
+        return 0
+
+    files: list[str] = []
+    if args.backfill:
+        files = sorted(glob.glob(os.path.join(args.backfill, "batch_*.json")))
+        if not files:
+            print(f"[WARN] No batch_*.json files found in {args.backfill}", file=sys.stderr)
+            conn.close()
+            return 0
+    elif args.report:
+        files = [args.report]
+
+    inserted = 0
+    for path in files:
+        try:
+            with open(path) as f:
+                report = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"[ERROR] Failed to read {path}: {e}", file=sys.stderr)
+            continue
+
+        if store_report(conn, config, report, filename=path):
+            bid = report.get("batch_id") or os.path.splitext(os.path.basename(path))[0]
+            jobs = (
+                report.get("job_results") or report.get("job_summaries") or report.get("jobs", [])
+            )
+            inserted += 1
+            print(f"[OK] Stored {bid} ({len(jobs)} jobs)")
+            try:
+                store_cross_patterns(conn, config, report)
+            except Exception as e:
+                print(f"[WARN] Failed to store cross_job_patterns: {e}", file=sys.stderr)
+
+    conn.close()
+    print(f"[DONE] {inserted}/{len(files)} report(s) stored in {config['results_table']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/batch-rca-automation/scripts/utils.py
+++ b/deploy/batch-rca-automation/scripts/utils.py
@@ -1,0 +1,52 @@
+"""Shared database utilities for batch RCA automation scripts."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import psycopg2
+import psycopg2.extras
+from dotenv import load_dotenv
+
+ALL_CONFIG_KEYS = {
+    "host": ("SOURCE_DB_HOST", "localhost"),
+    "port": ("SOURCE_DB_PORT", "5432"),
+    "name": ("SOURCE_DB_NAME", ""),
+    "user": ("SOURCE_DB_USER", ""),
+    "password": ("SOURCE_DB_PASSWORD", ""),
+    "source_table": ("SOURCE_DB_TABLE", ""),
+    "results_table": ("SOURCE_DB_RESULT_TABLE", ""),
+}
+
+
+def load_config(required: tuple[str, ...] = ("name", "user", "password")) -> dict[str, Any]:
+    env_file = os.path.join(os.path.dirname(__file__), "..", ".env")
+    if os.path.exists(env_file):
+        load_dotenv(env_file)
+
+    config: dict[str, Any] = {}
+    for key, (env_var, default) in ALL_CONFIG_KEYS.items():
+        val = os.environ.get(env_var, default)
+        config[key] = int(val) if key == "port" else val
+
+    errors = [f"{ALL_CONFIG_KEYS[k][0]} is required" for k in required if not config.get(k)]
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        raise SystemExit(1)
+
+    return config
+
+
+def connect_db(config: dict[str, Any], *, use_dict_cursor: bool = False) -> Any:
+    kwargs: dict[str, Any] = {
+        "host": config["host"],
+        "port": config["port"],
+        "dbname": config["name"],
+        "user": config["user"],
+        "password": config["password"],
+    }
+    if use_dict_cursor:
+        kwargs["cursor_factory"] = psycopg2.extras.RealDictCursor
+    return psycopg2.connect(**kwargs)


### PR DESCRIPTION
Batch headless script that queries unanalyzed jobs, spawns parallel Claude agents for root cause analysis, and aggregates results into a structured JSON report. Post-analysis matching in store_report.py uses difflib to deduplicate results and assign FK references.

The batch analysis flow now works like this:

Step 1(Log Fetching) - Queries the source table for job ids that haven't been processed and the associated bastion and path.

Step 1b(Pre-filter matching) - Matches the catalog_item of new incoming jobs to past catalog_item (4hr lookback window) to see if there's correlation there and it can skip the agent analysis.

Step 2-4 remain the same

Step 5(Historical data matching) - Takes in historical data and matches it to incoming batch to see if there are any duplicates. If there are duplicates the incoming job won't be queried but linked instead to the issue that was being duplicated. If it is new it will be queried to the database.

How to test:

Set up the new  `settings.json` and put it udner `deploy/batch-rc-automation/.claude/`, set up the ssh tunnel, and run `batch_rca-headless.sh`