### PR TITLE
Added Skill as an allowed tool

### DIFF
--- a/deploy/batch-rca-automation/batch_rca_headless.sh
+++ b/deploy/batch-rca-automation/batch_rca_headless.sh
@@ -272,7 +272,7 @@ cd "$SCRIPT_DIR" || exit 1
 
 CLAUDE_STDERR_FILE=$(mktemp)
 claude -p \
-  --allowedTools "Agent,Bash,Read,Write,mcp__github__search_code,mcp__github__get_file_contents" \
+  --allowedTools "Agent,Bash,Read,Write,Skill,mcp__github__search_code,mcp__github__get_file_contents" \
   --model claude-sonnet-4-6 \
   "$CLAUDE_PROMPT" 2>"$CLAUDE_STDERR_FILE" || {
   echo "[ERROR] Claude execution failed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ addopts = "-v --tb=short"
 [tool.ruff]
 target-version = "py310"
 line-length = 100
+extend-exclude = ["*.md"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
When batch analysis runs and there is only one job to run, Claude will invoke the skill directly instead of spawning sub-agents that then use the skill. It previously didn't have permission to use the Skill tool so the batch would fail. Adding Skill as an allowed tool fixes this issue.