### PR TITLE
fix: instead of using job_started column to query jobs use job_finished

### DIFF
--- a/deploy/batch-rca-automation/scripts/query_source_db.py
+++ b/deploy/batch-rca-automation/scripts/query_source_db.py
@@ -22,7 +22,7 @@ def query_job_ids(
     params: list[Any] = []
 
     if since:
-        conditions.append("job_started >= %s")
+        conditions.append("job_finished >= %s")
         params.append(since)
 
     suffix = ""


### PR DESCRIPTION
Using job_started column to fetch job logs would sometimes skip over certain jobs. Using job_finished ensures that no jobs will be skipped over, and the jobs are complete